### PR TITLE
changed freeswitch.yml for harvestor_limit from 5000 to 1000; for avo…

### DIFF
--- a/dashcomm/ansible/roles/filebeat/templates/configs/freeswitch.yml
+++ b/dashcomm/ansible/roles/filebeat/templates/configs/freeswitch.yml
@@ -6,7 +6,7 @@
   multiline.negate: true
   multiline.match: after
   close_inactive: 90s
-  harvester_limit: 5000
+  harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true
   clean_removed: true
@@ -42,7 +42,7 @@
   json.keys_under_root: true
   json.add_error_key: true
   close_inactive: 90s
-  harvester_limit: 5000
+  harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true
   clean_removed: true


### PR DESCRIPTION
update the dashcomm/ansible/roles/filebeat/templates/configs/freeswitch.yml file

change the havestor_limit from 5000 to 1000

this is to avoid hitting too many open files  issue after running the ansible playbook to deploy filebeat and telegraf