### PR TITLE
fix protocol and port issues with Filebeat and PushGateway; make _message_parser optional

### DIFF
--- a/dashbase/ansible/README.md
+++ b/dashbase/ansible/README.md
@@ -33,14 +33,14 @@
         192.84.16.128
 
         ; See further configurations in https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
-        ; [syslog_hosts:vars]
+        ; [filebeat_hosts:vars]
         ; ansible_user=admin
 
      2) Run the playbook
 
-       >ansible-playbook -i inventory deploy.yml -e "dashbase_url=table-freeswitch.cluster1.dashbase.io configs=syslog"
+       >ansible-playbook -i inventory deploy.yml -e "dashbase_url=http://table-freeswitch.cluster1.dashbase.io:80 configs=syslog"
 
         Playbook takes these extra variables with -e (or will prompt for):
 
-        dashbase_url     - URL of the dashbase table to send logs to
+        dashbase_url     - URL of the dashbase table to send logs to (the http protocol and port are required)
         configs          - name(s) of the filebeat "yml" files without ".yml" (multiple values can be given as a comma separated list)

--- a/dashbase/ansible/deploy.yml
+++ b/dashbase/ansible/deploy.yml
@@ -20,8 +20,8 @@
     prometheus_pushgateway_enable: True
     configs_list: "{{ configs.split(',') }}"
     table: "{{ dashbase_url.strip('http://').strip('https://').split('.')[0].strip('table-') }}"
-    pushgateway_url: "pushgateway.{{ dashbase_url.split('.')[1:] | join('.')}}"
+    pushgateway_url: "{{ dashbase_url.split('//')[0] }}//pushgateway.{{ dashbase_url.split('.')[1:] | join('.') | regex_replace(':(\\d+)$') }}"
     prometheus_local_exporter_url: http://localhost:29273/metrics
-    prometheus_pushgateway_url: https://{{ pushgateway_url }}/metrics/job/filebeat/instance/{{ ansible_hostname }}
+    prometheus_pushgateway_url: "{{ pushgateway_url }}/metrics/job/filebeat/instance/{{ ansible_hostname }}"
     nightwatch_version: 1.1.1
     nightwatch_configs: ""

--- a/dashbase/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/dashbase/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -29,13 +29,17 @@ queue.mem:
 processors:
   - add_locale: ~
   - rename:
-     fields:
-      - from: "beat.timezone"
-        to: "fields._message_parser.defaultTimeZone"
-      - from: "beat.hostname"
-        to: "hostname"
+      when:
+        has_fields: ['fields._message_parser']
+      fields:
+        - from: "beat.timezone"
+          to: "fields._message_parser.defaultTimeZone"
+  - rename:
+      fields:
+        - from: "beat.hostname"
+          to: "hostname"
   - drop_fields:
-      fields: ["offset", "beat", "prospector", "host", "offset", "input"]
+      fields: ["offset", "beat", "prospector", "host", "input"]
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
@@ -52,7 +56,6 @@ output.elasticsearch:
   compression_level: 5
   hosts: "{{ dashbase_url }}"
   index: "{{ table }}"
-  protocol: "http"
 
 #================================ Logging =====================================
 


### PR DESCRIPTION
Major changes:
1. Remove hardcoded `http` in Filebeat and `https` in `pushgateway_url`
2. Require users to input `dashbase_url` with protocol and schema. (Otherwise, filebeat will connect `9200` by default)
3. Update Filebeat processors to allow users not specify `_message_parser`.

Tested locally.