### PR TITLE
DB-713 verify k8s resource running

### DIFF
--- a/verfiy-dashbase-resources.sh
+++ b/verfiy-dashbase-resources.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # check statefulsets
+echo "Checking Statefulsets pods..."
 for STS_INFO in $(kubectl get statefulsets -o=jsonpath='{range .items[*]}{.metadata.name},{.spec.replicas}{"\n"}{end}' -n dashbase); do
   read -r STS_NAME STS_REPLICAS <<<"$(echo "$STS_INFO" | tr ',' ' ')"
   if [ $STS_REPLICAS -lt 1 ]; then
@@ -19,9 +20,11 @@ for STS_INFO in $(kubectl get statefulsets -o=jsonpath='{range .items[*]}{.metad
 done
 
 # check deployment
+echo "Checking Deployments..."
 kubectl wait --for=condition=Available deployment --all -n dashbase
 
 # check ingress-nginx-ingress-controller svc must have an external ip
+echo "Checking Ingress External IP..."
 if kubectl get svc ingress-nginx-ingress-controller -n dashbase &>/dev/null; then
   EXTERNAL_IP=$(kubectl get svc ingress-nginx-ingress-controller -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' -n dashbase)
   if [[ $EXTERNAL_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/verfiy-dashbase-resources.sh
+++ b/verfiy-dashbase-resources.sh
@@ -27,7 +27,7 @@ kubectl wait --for=condition=Available deployment --all -n dashbase
 echo "Checking Ingress External IP..."
 if kubectl get svc ingress-nginx-ingress-controller -n dashbase &>/dev/null; then
   EXTERNAL_IP=$(kubectl get svc ingress-nginx-ingress-controller -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' -n dashbase)
-  if [[ $EXTERNAL_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ -n "$EXTERNAL_IP" ]]; then
     echo "Ingress: External IP is ready"
   else
     echo "Ingress: External IP is not ready"

--- a/verfiy-dashbase-resources.sh
+++ b/verfiy-dashbase-resources.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# check statefulsets
+for STS_INFO in $(kubectl get statefulsets -o=jsonpath='{range .items[*]}{.metadata.name},{.spec.replicas}{"\n"}{end}' -n dashbase); do
+  read -r STS_NAME STS_REPLICAS <<<"$(echo "$STS_INFO" | tr ',' ' ')"
+  if [ $STS_REPLICAS -lt 1 ]; then
+    :
+  elif [ $STS_REPLICAS -eq 1 ]; then
+    kubectl wait --for=condition=Ready pods/"${STS_NAME}"-0 -n dashbase
+  else
+    ((STS_REPLICAS--))
+    REPLICAS_SERIES=$(seq -s , 0 "$STS_REPLICAS")
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      REPLICAS_SERIES="${REPLICAS_SERIES%?}"
+    fi
+    REPLICAS_SERIES="{${REPLICAS_SERIES}}"
+    kubectl wait --for=condition=Ready pods/"${STS_NAME}"-"${REPLICAS_SERIES}" -n dashbase
+  fi
+done
+
+# check deployment
+kubectl wait --for=condition=Available deployment --all -n dashbase
+
+# check ingress-nginx-ingress-controller svc must have an external ip
+if kubectl get svc ingress-nginx-ingress-controller -n dashbase &>/dev/null; then
+  EXTERNAL_IP=$(kubectl get svc ingress-nginx-ingress-controller -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' -n dashbase)
+  if [[ $EXTERNAL_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Ingress: External IP is ready"
+  else
+    echo "Ingress: External IP is not ready"
+  fi
+else
+  echo "Warning: Ingress is not installed in this namespace."
+fi


### PR DESCRIPTION
Tested both on MacOS and Alpine Linux.

Example output:
```
bash-5.0# ./verify.sh
Checking Statefulsets pods...
pod/auth-0 condition met
pod/elasticsearch-0 condition met
pod/etcd-0 condition met
pod/grafana-0 condition met
pod/influxdb-0 condition met
pod/kafka-0 condition met
pod/prometheus-0 condition met
pod/table-filebeat-0 condition met
pod/web-0 condition met
pod/zookeeper-0 condition met
Checking Deployments...
deployment.extensions/api condition met
deployment.extensions/chaodebug-kube-state-metrics condition met
deployment.extensions/deployment condition met
deployment.extensions/ingress-nginx-ingress-controller condition met
deployment.extensions/ingress-nginx-ingress-default-backend condition met
Checking Ingress External IP...
Ingress: External IP is ready
```