### PR TITLE
id type to id instead of text

### DIFF
--- a/dashbase/ansible/roles/filebeat/templates/configs/freepbx.yml
+++ b/dashbase/ansible/roles/filebeat/templates/configs/freepbx.yml
@@ -19,10 +19,10 @@
           parsers:
             freepbx:
               type: grok
-              pattern: "\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:id}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
+              pattern: "\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:key}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
             asterisk:
               type: grok
-              pattern: "\\[%{SYSLOGTIMESTAMP:timestamp:datetime:MMM ppd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:id}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
+              pattern: "\\[%{SYSLOGTIMESTAMP:timestamp:datetime:MMM ppd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:key}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
         sip:
           type: sip
 

--- a/dashbase/ansible/roles/filebeat/templates/configs/freepbx.yml
+++ b/dashbase/ansible/roles/filebeat/templates/configs/freepbx.yml
@@ -19,10 +19,10 @@
           parsers:
             freepbx:
               type: grok
-              pattern: "\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:text}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
+              pattern: "\\[%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:id}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
             asterisk:
               type: grok
-              pattern: "\\[%{SYSLOGTIMESTAMP:timestamp:datetime:MMM ppd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:text}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
+              pattern: "\\[%{SYSLOGTIMESTAMP:timestamp:datetime:MMM ppd HH:mm:ss}\\] %{WORD:level:meta}\\[%{INT:lwp:int}\\](\\[%{DATA:callid:id}\\])? %{JAVAFILE:source:meta}: %{GREEDYDATA:message}"
         sip:
           type: sip
 

--- a/dashbase/ansible/roles/filebeat/templates/configs/freeswitch.yml
+++ b/dashbase/ansible/roles/filebeat/templates/configs/freeswitch.yml
@@ -17,7 +17,7 @@
      - name: freeswitch
        config:
          type: grok
-         pattern: "(?:%{UUID:uuid:id} |)%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss.SSSSSS} \\[%{WORD:level:meta}\\] %{JAVAFILE:source:meta}:%{INT:line:int} %{GREEDYDATA:message}"
+         pattern: "(?:%{UUID:uuid:key} |)%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss.SSSSSS} \\[%{WORD:level:meta}\\] %{JAVAFILE:source:meta}:%{INT:line:int} %{GREEDYDATA:message}"
      - name: sip
        config:
          type: multi
@@ -32,7 +32,7 @@
      - name: universal
        config:
          type: grok
-         pattern: "(?:%{UUID:uuid:id} |)%{GREEDYDATA:message}"
+         pattern: "(?:%{UUID:uuid:key} |)%{GREEDYDATA:message}"
 
 - paths:
    - /var/log/freeswitch/json_cdr/*/*.cdr.json

--- a/dashbase/ansible/roles/filebeat/templates/configs/freeswitch.yml
+++ b/dashbase/ansible/roles/filebeat/templates/configs/freeswitch.yml
@@ -17,7 +17,7 @@
      - name: freeswitch
        config:
          type: grok
-         pattern: "(?:%{UUID:uuid:text} |)%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss.SSSSSS} \\[%{WORD:level:meta}\\] %{JAVAFILE:source:meta}:%{INT:line:int} %{GREEDYDATA:message}"
+         pattern: "(?:%{UUID:uuid:id} |)%{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd HH:mm:ss.SSSSSS} \\[%{WORD:level:meta}\\] %{JAVAFILE:source:meta}:%{INT:line:int} %{GREEDYDATA:message}"
      - name: sip
        config:
          type: multi
@@ -32,7 +32,7 @@
      - name: universal
        config:
          type: grok
-         pattern: "(?:%{UUID:uuid:text} |)%{GREEDYDATA:message}"
+         pattern: "(?:%{UUID:uuid:id} |)%{GREEDYDATA:message}"
 
 - paths:
    - /var/log/freeswitch/json_cdr/*/*.cdr.json


### PR DESCRIPTION
uuid and callid should be of `id` type, instead of `text`, this avoids tokenization and allows the ability to do regex matching on the id data.