### PR TITLE
Remove presto CN prefix

### DIFF
--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/https_presto2.sh
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/https_presto2.sh
@@ -35,7 +35,7 @@ echo "Creating presto-keystore file"
 
 keytool -genkey -noprompt \
  -alias dashbase \
- -dname "CN=$NAMESPACE-presto-coordinator-0.$NAMESPACE-presto-coordinator.$NAMESPACE.svc.cluster.local, OU=Engineering, O=Dashbase, L=Santa clara, S=CA, C=US" \
+ -dname "CN=presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local, OU=Engineering, O=Dashbase, L=Santa clara, S=CA, C=US" \
  -keystore presto-keystore \
  -storepass $KEYSTORE_PASSWORD \
  -keypass $KEYSTORE_PASSWORD \
@@ -59,7 +59,7 @@ echo "1. presto-kestore  java keystore for presto"
 echo "2. presto-keystore.p12 P12 format file for presto-keystore"
 echo "3. presto-cert.pem base 64 cert file for presto"
 echo "4. presto-key.pem  base 64 key file for presto"
-echo "The CN of this self-signed cert is $NAMESPACE-presto-coordinator-0.$NAMESPACE-presto-coordinator.$NAMESPACE.svc.cluster.local"
+echo "The CN of this self-signed cert is presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local"
 
 # create Base 64 encryption for generated key, cert, keystore, keystore password
 

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/https_presto_v2.sh
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/https_presto_v2.sh
@@ -35,7 +35,7 @@ echo "Creating presto-keystore file"
 
 keytool -genkey -noprompt \
  -alias dashbase \
- -dname "CN=$NAMESPACE-presto-coordinator-0.$NAMESPACE-presto-coordinator.$NAMESPACE.svc.cluster.local, OU=Engineering, O=Dashbase, L=Santa clara, S=CA, C=US" \
+ -dname "CN=presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local, OU=Engineering, O=Dashbase, L=Santa clara, S=CA, C=US" \
  -keystore presto-keystore \
  -storepass $KEYSTORE_PASSWORD \
  -keypass $KEYSTORE_PASSWORD \
@@ -59,7 +59,7 @@ echo "1. presto-kestore  java keystore for presto"
 echo "2. presto-keystore.p12 P12 format file for presto-keystore"
 echo "3. presto-cert.pem base 64 cert file for presto"
 echo "4. presto-key.pem  base 64 key file for presto"
-echo "The CN of this self-signed cert is $NAMESPACE-presto-coordinator-0.$NAMESPACE-presto-coordinator.$NAMESPACE.svc.cluster.local"
+echo "The CN of this self-signed cert is presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local"
 
 # create Base 64 encryption for generated key, cert, keystore, keystore password
 

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/https_presto2.sh
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/https_presto2.sh
@@ -35,7 +35,7 @@ echo "Creating presto-keystore file"
 
 keytool -genkey -noprompt \
  -alias dashbase \
- -dname "CN=$NAMESPACE-presto-coordinator-0.$NAMESPACE-presto-coordinator.$NAMESPACE.svc.cluster.local, OU=Engineering, O=Dashbase, L=Santa clara, S=CA, C=US" \
+ -dname "CN=presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local, OU=Engineering, O=Dashbase, L=Santa clara, S=CA, C=US" \
  -keystore presto-keystore \
  -storepass $KEYSTORE_PASSWORD \
  -keypass $KEYSTORE_PASSWORD \
@@ -59,7 +59,7 @@ echo "1. presto-kestore  java keystore for presto"
 echo "2. presto-keystore.p12 P12 format file for presto-keystore"
 echo "3. presto-cert.pem base 64 cert file for presto"
 echo "4. presto-key.pem  base 64 key file for presto"
-echo "The CN of this self-signed cert is $NAMESPACE-presto-coordinator-0.$NAMESPACE-presto-coordinator.$NAMESPACE.svc.cluster.local"
+echo "The CN of this self-signed cert is presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local"
 
 # create Base 64 encryption for generated key, cert, keystore, keystore password
 


### PR DESCRIPTION
We don't need the $NAMESPACE of prefix now.
After merged this RP 
https://github.com/dashbase/dashbase-k8s/pull/215
Whatever release name we use, we can use static the CN 
**_presto-coordinator-0.presto-coordinator.$NAMESPACE.svc.cluster.local_**

refer: we can find more detail here 
https://github.com/dashbase/dashbase-k8s/blob/634ed4ef93f6f68ac495bfa88542b514affc3d5d/presto/templates/_helpers.tpl#L14  