### PR TITLE
Fix on DB-1023, DB-1024, DB-1040

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ license: "license"
 
 Run update_license.sh, with username and license. **Don't need ""**
 ```
-./deployment-tools/update_license.sh --username=username --license=license
+./deployment-tools/upgrade-dashbase.sh --username=username --license=license
 ```
 
 Upgrade dashbase version
@@ -75,7 +75,7 @@ Run upgrade-dashbase.sh script and specify dashbase version
 options used on upgrade script
 
      --version        specify dashbase version
-     --chartversion   optional entry for dashbase helm chart version, if missing will use default version in repo
+     --chartversion   optional entry for dashbase helm chart version, if missing will match with dashbase version
      --username       username for license information
      --license        dashbase license string
 
@@ -99,7 +99,8 @@ Install log file is saved in your current directory when running the script, the
 The create-aws-eks.sh script provides an easy way to create a basic AWS EKS cluster for dashbase installation purpose
 You can use this script to setup AWS EKS cluster and install dashbase at the same time.
 By default, the script will create an EKS cluster on us-east-2a with three worker nodes of size R5.2xlarge
-Download the create-aws-eks.sh script and input your AWS Access Key as shown from following example
+Download the create-aws-eks.sh script and input your AWS Access Key as shown from following examples
+** The following AWS key and secrets are just samples, please your own key and secrets from your account **
 
 ```
 chmod a+x create-aws-eks.sh


### PR DESCRIPTION
change on this PR is mainly to address on issues DB-1023, DB-1024, and DB-1040 and added improvement on dashbase version checking

DB-1023 -- command not found sometimes happens on upgrade-dashbase.sh script
DB-1024 -- upgrade script should not allow downgrade dashbase version
DB-1040 -- display grafana url when expose endpoints using ingress 

make  dashbase-installer.sh script default using dashbase version 1.1.0-rc1  
improve dashbase version checking for entered version string and verify with github registry
check dashbase version creation time stamp and disable upgrade using an older version of dashbase

By default if no version is specified  for dashbase-install script will use default 1.1.0-rc1
and if no version is specified  for upgrade-dashbase.sh script, will use current dashbase version

upgrade-dashbase.sh script can do dashbase version upgrade and as well as license update. 
README.md file is updated to use upgrade-dashbase.sh script to update license