### PR TITLE
updated upgrade-dashbase.sh script support devel & current chart version during upgrade

### DIFF
--- a/deployment-tools/upgrade-dashbase.sh
+++ b/deployment-tools/upgrade-dashbase.sh
@@ -149,6 +149,9 @@ elif [[ "$CHARTVERSION" == "undefined" ]] && [[ "$VERSION" != "undefined"  ]]; t
   echo "Dashbase version is provided and chart version is not provided"
   echo "Both dashbase version and chart version will be in version $VERSION"
   chartver="--version $VERSION"
+elif [[ "$CHARTVERSION" == "devel" ]]; then
+  echo "Entered chart version is latest development version"
+  chartver="--devel"
 elif [[ "$CHARTVERSION" != "undefined" ]]; then
   echo "Entered chart version is $CHARTVERSION"
   chartver="--version $CHARTVERSION"

--- a/deployment-tools/upgrade-dashbase.sh
+++ b/deployment-tools/upgrade-dashbase.sh
@@ -132,11 +132,11 @@ check_version() {
 # Check chart version
 # if chart version is not provided, then will use whatever previously is used
 check_chart_version() {
+chart_version=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "helm ls '^dashbase$' |grep 'dashbase' |  awk '{print \$9}' |  cut -c 10-  ")
+
 if [[ "$CHARTVERSION" == "undefined" ]] && [[ "$VERSION" == "undefined" ]]; then
   echo "Both dashbase version and chart version are not provided"
   echo "checking previous chart version is used in the deployment"
-  chart_version=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "helm ls '^dashbase$' |grep 'dashbase' |  awk '{print \$9}' |  cut -c 10-  ")
-
   if [[ $chart_version == \>* ]]; then
     echo "current chart version is using latest devel, and will continue using devel chart version"
     chartver="--devel"
@@ -152,6 +152,9 @@ elif [[ "$CHARTVERSION" == "undefined" ]] && [[ "$VERSION" != "undefined"  ]]; t
 elif [[ "$CHARTVERSION" == "devel" ]]; then
   echo "Entered chart version is latest development version"
   chartver="--devel"
+elif [[ "$CHARTVERSION" == "current" ]]; then
+  echo "Entered chart version is using current version $chart_version"
+  chartver="--version $chart_version"
 elif [[ "$CHARTVERSION" != "undefined" ]]; then
   echo "Entered chart version is $CHARTVERSION"
   chartver="--version $CHARTVERSION"


### PR DESCRIPTION
Changes in this PR 

1. updated the upgrade-dashbase.sh script to support chart version flag when user entering devel e.g. --chartversion=devel .   And this will convert as helm option using "--devel"

In normal upgrade, chart version doesn't need to be provided; because it will automatically match with your dashbase version. However, if you want to try nightly dashbase version, and you can either use current chart version or use latest devel version by entering flags like below

--chartversion=current
or 
--chartversion=devel


Similarly when user entered a dashbase version e.g. 1.1.0-rc2 but want to keep using the current chart version, then it can be done as follows
--version=1.1.0-rc2  --chartversion=current


