### PR TITLE
fix missing default dashbase version when no input version specified

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -209,6 +209,7 @@ check_node() {
 
 check_version() {
   if [ -z "$VERSION" ]; then
+    VERSION=$DASHVERSION
     log_info "No input dashbase version, use default version $DASHVERSION"
   else
     log_info "Dashbase version entered is $VERSION"


### PR DESCRIPTION
Changes in this PR

1.  fix missing dashbase version, the variable VERSION should be equal to DASHVERSION  when version is not specified. It was echo on the message but not explicitly defined. 