### PR TITLE
DB-1040 missing IP when using ingress flag

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -486,7 +486,7 @@ echo "Exposed endpoints are below"
 if [[ "$INGRESS_FLAG" == "true"  ]]; then
    echo ""
    echo "Update your DNS server with the following ingress controller IP to map with this name *.$SUBDOMAIN"
-   kubectl get svc -n dashbase |grep ingress-nginx-ingress-controller |awk '{print $1 "    " $4}'
+   kubectl get svc -n dashbase |grep nginx-ingress-controller |awk '{print $1 "    " $4}'
    echo "Access to dashbase web UI with https://web.$SUBDOMAIN"
    echo "Access to dashbase table endpoint with https://table-logs.$SUBDOMAIN"
    echo "Access to dashbase grafana endpoint with https://grafana.$SUBDOMAIN"

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -484,7 +484,7 @@ echo "Exposed endpoints are below"
 if [[ "$INGRESS_FLAG" == "true"  ]]; then
    echo ""
    echo "Update your DNS server with the following ingress controller IP to map with this name *.$SUBDOMAIN"
-   kubectl get svc -n dashbase |grep ingress-nginx-ingress-controller |awk '{print $1 "    " $4}'
+   kubectl get svc -n dashbase |grep nginx-ingress-controller |awk '{print $1 "    " $4}'
    echo "Access to dashbase web UI with https://web.$SUBDOMAIN"
    echo "Access to dashbase table endpoint with https://table-logs.$SUBDOMAIN"
    echo "Access to dashbase grafana endpoint with https://grafana.$SUBDOMAIN"


### PR DESCRIPTION
Changes on this PR

1. when using "--ingress" flag on dashbase-installer.sh script,  the external IP address of ingress controller is not listed on the final output.  This changes fix the issue to ensure ingress controller IP address is displayed so user can update the DNS accordingly.

Change is tested on AWS EKS setup