### PR TITLE
Fix issue on missing fail_if_empty function on setup_aws_cli.sh

### DIFF
--- a/deployment-tools/setup_aws_cli.sh
+++ b/deployment-tools/setup_aws_cli.sh
@@ -18,6 +18,11 @@ function log_fatal() {
   exit 1
 }
 
+function fail_if_empty() {
+  [[ -z "$2" ]] && log_fatal "Parameter $1 must have a value."
+  return 0
+}
+
 echo "$@" >setup_arguments
 echo "$#" >no_arguments
 


### PR DESCRIPTION
changes in this PR

1. Fix the issue on missing fail_if_empty function on setup_aws_cli.sh script.

without this function exit condition may be an issue when parsing the input parameters