### PR TITLE
Fixing typo and output log to /tmp insteasd of current folder

### DIFF
--- a/centos_setup_eks_dashbase.sh
+++ b/centos_setup_eks_dashbase.sh
@@ -34,8 +34,8 @@ function fail_if_empty() {
   return 0
 }
 
-echo "$@" >setup_arguments
-echo "$#" >no_arguments
+echo "$@" > /tmp/setup_arguments
+echo "$#" > /tmp/no_arguments
 
 while [[ $# -gt 0 ]]; do
   PARAM=${1%%=*}

--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -26,8 +26,8 @@ function fail_if_empty() {
   return 0
 }
 
-echo "$@" >setup_arguments
-echo "$#" >no_arguments
+echo "$@" > /tmp/setup_arguments
+echo "$#" > /tmp/no_arguments
 
 while [[ $# -gt 0 ]]; do
   PARAM=${1%%=*}
@@ -535,4 +535,4 @@ else
 
 fi
 
-} 2>&1 | tee -a dashbase_install_"$(date +%d-%m-%Y_%H-%M-%S)".log
+} 2>&1 | tee -a /tmp/dashbase_install_"$(date +%d-%m-%Y_%H-%M-%S)".log

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -26,8 +26,8 @@ function fail_if_empty() {
   return 0
 }
 
-echo "$@" >setup_arguments
-echo "$#" >no_arguments
+echo "$@" > /tmp/setup_arguments
+echo "$#" > /tmp/no_arguments
 
 while [[ $# -gt 0 ]]; do
   PARAM=${1%%=*}
@@ -533,4 +533,4 @@ else
 
 fi
 
-} 2>&1 | tee -a dashbase_install_"$(date +%d-%m-%Y_%H-%M-%S)".log
+} 2>&1 | tee -a /tmp/dashbase_install_"$(date +%d-%m-%Y_%H-%M-%S)".log

--- a/deployment-tools/remove_aws_eks.sh
+++ b/deployment-tools/remove_aws_eks.sh
@@ -22,8 +22,8 @@ function fail_if_empty() {
   return 0
 }
 
-echo "$@" >setup_arguments
-echo "$#" >no_arguments
+echo "$@" > /tmp/setup_arguments
+echo "$#" > /tmp/no_arguments
 
 while [[ $# -gt 0 ]]; do
   PARAM=${1%%=*}
@@ -59,7 +59,7 @@ check_uninstall_script() {
   if [ -f dashbase-installation/deployment-tools/uninstall-dashbase.sh ]; then
     log_info "Dashbase uninstallation script is found"
   else
-    log_infor "Dashbase uninstallation script is not found, downloading"
+    log_info "Dashbase uninstallation script is not found, downloading"
     /usr/bin/git clone https://github.com/dashbase/dashbase-installation.git
   fi
 }
@@ -70,7 +70,7 @@ run_by_root
 check_commands
 check_uninstall_script
 
-OLDCLUSTERNAME=$(aws eks list-clusters --region us-west-2 --output  text |grep mydash |awk '{ print $2 }')
+OLDCLUSTERNAME=$(aws eks list-clusters --region $REGION --output  text |grep mydash |awk '{ print $2 }')
 
 if [ -z "$REGION" ]; then log_fatal "Missing AWS region"; fi
 
@@ -88,10 +88,4 @@ dashbase-installation/deployment-tools/uninstall-dashbase.sh
 
 # remove RKS cluster
 /usr/local/bin/eksctl delete cluster --name "$OLDCLUSTERNAME" --region "$REGION"
-
-
-
-
-
-
 

--- a/deployment-tools/upgrade-dashbase.sh
+++ b/deployment-tools/upgrade-dashbase.sh
@@ -35,8 +35,8 @@ function run_catch() {
   fi
 }
 
-echo "$@" >setup_arguments
-echo "$#" >no_arguments
+echo "$@" > /tmp/setup_arguments
+echo "$#" > /tmp/no_arguments
 
 while [[ $# -gt 0 ]]; do
   PARAM=${1%%=*}


### PR DESCRIPTION
Changes in this PR

1. fix two typo in remove_aws_eks.sh script
2. change all output log files or files caused by this script to /tmp folder