### PR TITLE
change dashbase version from 1.1.1 to 1.2.1

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -5,7 +5,7 @@ INGRESS_FLAG="false"
 VALUEFILE="dashbase-values.yaml"
 USERNAME="undefined"
 LICENSE="undefined"
-DASHVERSION="1.1.1"
+DASHVERSION="1.2.1"
 
 # log functions and input flag setup
 function log_info() {

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -5,7 +5,7 @@ INGRESS_FLAG="false"
 VALUEFILE="dashbase-values.yaml"
 USERNAME="undefined"
 LICENSE="undefined"
-DASHVERSION="1.1.1"
+DASHVERSION="1.2.1"
 
 # log functions and input flag setup
 function log_info() {


### PR DESCRIPTION
Changes in this PR

updated dashbase version from 1.1.1 to 1.2.1  on the installation scripts: dashbase-installer.sh  and dashbase-installer-smallsetup.sh 