### PR TITLE
fix the template issue

### DIFF
--- a/log-collection/ansible/roles/filebeat/tasks/Configure.yml
+++ b/log-collection/ansible/roles/filebeat/tasks/Configure.yml
@@ -8,9 +8,9 @@
 
 ## Copy app related config files
 - name: Copy filebeat app config files
-  template:
-    src: "configs/{{ item }}.yml"
-    dest: "/etc/filebeat/configs/"
+  copy:
+    src: "templates/configs/{{ item }}.yml"
+    dest: "/etc/filebeat/configs/{{ item }}.yml"
   with_items:
     "{{ configs_list }}"
 


### PR DESCRIPTION
When using the pattern `%{DATA:timestamp:datetime:MMM ppd HH:mm:ss} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource:meta} %{SYSLOGPROG}: %{WORD:level:meta}: \{%{DATA:method:meta}\} - \{%{DATA:call-id:meta}\}%{GREEDYDATA:message}`, Ansible will raise an error like:
```
failed: [18.182.3.99] (item=chaotest) => {"ansible_loop_var": "item", "changed": false, "item": "chaotest", "msg": "AnsibleError: template error while templating string: tag name expected. String: - type: log\n  paths:\n    - /var/log/ingress.log\n    - /var/log/egress.log\n  fields:\n    _message_parser:\n      type: multi\n      parsers_list:\n        - name: grok\n          config:\n            type: grok\n            pattern: |-\n              %{DATA:timestamp:datetime:MMM ppd HH:mm:ss} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource:meta} %{SYSLOGPROG}: %{WORD:level:meta}: \\{%{DATA:method:meta}\\} - \\{%{DATA:call-id:meta}\\}%{GREEDYDATA:message}\n ...
```

The pattern is correct so I changed `template` to `copy` as we're not using template features in Filebeat inputs.

Verified on Ubuntu 18.04