### PR TITLE
updated default installer script version from 1.2.3 to 1.2.4

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -5,7 +5,7 @@ INGRESS_FLAG="false"
 VALUEFILE="dashbase-values.yaml"
 USERNAME="undefined"
 LICENSE="undefined"
-DASHVERSION="1.2.3"
+DASHVERSION="1.2.4"
 
 # log functions and input flag setup
 function log_info() {

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -5,7 +5,7 @@ INGRESS_FLAG="false"
 VALUEFILE="dashbase-values.yaml"
 USERNAME="undefined"
 LICENSE="undefined"
-DASHVERSION="1.2.3"
+DASHVERSION="1.2.4"
 
 # log functions and input flag setup
 function log_info() {


### PR DESCRIPTION
Changes in this PR
update dashbase version from 1.2.3 to 1.2.4 on the dashbase-installer.sh and dashbase-installer-smallsetup.sh  script