### PR TITLE
unify field name over SIP capture tools

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/heplify.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/heplify.yml
@@ -21,7 +21,7 @@
             parsers:
               heplify_grok:
                 type: grok
-                pattern: "%{DATA:timestamp:datetime} %{WORD:level:meta} HEP packet:\\{Version:%{WORD:hep.version:meta},Protocol:%{WORD:hep.protocol:meta},SrcIP:%{IPORHOST:hep.src-ip:text},DstIP:%{IPORHOST:hep.dst-ip:text},SrcPort:%{INT:hep.src-port:text},DstPort:%{INT:hep.dst-port:text},Tsec:%{INT:hep.tsec:int},Tmsec:%{INT:hep.tmsec:int},ProtoType:%{WORD:hep.proto-type:meta},NodeID:%{WORD:hep.node-id:text},NodePW:(?:%{DATA:hep.node-pw:text}|),CID:(?:%{DATA:hep.cid:text}|),Vlan:(?:%{WORD:hep.vlan:text}|)\\} with Payload:%{GREEDYDATA:message}"
+                pattern: "%{DATA:timestamp:datetime} %{WORD:level:meta} HEP packet:\\{Version:%{WORD:capture.version:text},Protocol:%{WORD:capture.protocol:text},SrcIP:%{IPORHOST:capture.src.ip:text},DstIP:%{IPORHOST:capture.dst.ip:text},SrcPort:%{INT:capture.src.port:text},DstPort:%{INT:capture.dst.port:text},Tsec:%{INT:capture.tsec:int},Tmsec:%{INT:capture.tmsec:int},ProtoType:%{WORD:capture.proto-type:text},NodeID:%{WORD:capture.node-id:text},NodePW:(?:%{DATA:capture.node-pw:text}|),CID:(?:%{DATA:capture.cid:text}|),Vlan:(?:%{WORD:capture.vlan:text}|)\\} with Payload:%{GREEDYDATA:message}"
                 timestamp:
                   format: iso
               heplify_sip:

--- a/log-collection/ansible/roles/filebeat/templates/configs/heplify.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/heplify.yml
@@ -21,7 +21,7 @@
             parsers:
               heplify_grok:
                 type: grok
-                pattern: "%{DATA:timestamp:datetime} %{WORD:level:meta} HEP packet:\\{Version:%{WORD:capture.version:text},Protocol:%{WORD:capture.protocol:text},SrcIP:%{IPORHOST:capture.src.ip:text},DstIP:%{IPORHOST:capture.dst.ip:text},SrcPort:%{INT:capture.src.port:text},DstPort:%{INT:capture.dst.port:text},Tsec:%{INT:capture.tsec:int},Tmsec:%{INT:capture.tmsec:int},ProtoType:%{WORD:capture.proto-type:text},NodeID:%{WORD:capture.node-id:text},NodePW:(?:%{DATA:capture.node-pw:text}|),CID:(?:%{DATA:capture.cid:text}|),Vlan:(?:%{WORD:capture.vlan:text}|)\\} with Payload:%{GREEDYDATA:message}"
+                pattern: "%{DATA:timestamp:datetime} %{WORD:level:meta} HEP packet:\\{Version:%{WORD:capture.version:text},Protocol:%{WORD:capture.protocol:text},SrcIP:%{IPORHOST:capture.src.ip:text},DstIP:%{IPORHOST:capture.dst.ip:text},SrcPort:%{INT:capture.src.port:text},DstPort:%{INT:capture.dst.port:text},Tsec:%{INT:capture.tsec:int},Tmsec:%{INT:capture.tmsec:int},ProtoType:%{WORD:capture.proto.type:text},NodeID:%{WORD:capture.node.id:text},NodePW:(?:%{DATA:capture.node.pw:text}|),CID:(?:%{DATA:capture.cid:text}|),Vlan:(?:%{WORD:capture.vlan:text}|)\\} with Payload:%{GREEDYDATA:message}"
                 timestamp:
                   format: iso
               heplify_sip:

--- a/log-collection/ansible/roles/filebeat/templates/configs/kamailio.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/kamailio.yml
@@ -35,16 +35,16 @@
           pattern: |-
             \|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|
             ====================
-            tag: %{WORD:tag:meta}
-            pid: %{NUMBER:pid:int}
-            process: %{NUMBER:process:int}
-            time: %{NUMBER:time:double}
+            tag: %{WORD:capture.tag:text}
+            pid: %{NUMBER:capture.pid:int}
+            process: %{NUMBER:capture.process:int}
+            time: %{NUMBER:capture.time:double}
             date: %{DATA:timestamp:datetime:EEE MMM dd HH:mm:ss yyyy}
-            proto: %{DATA:proto:text}
-            srcip: %{IPORHOST:src-ip:text}
-            srcport: %{INT:src-port:text}
-            dstip: %{IPORHOST:dst-ip:text}
-            dstport: %{INT:dst-port:text}
+            proto: %{DATA:capture.proto:text}
+            srcip: %{IPORHOST:capture.src.ip:text}
+            srcport: %{INT:capture.src.port:text}
+            dstip: %{IPORHOST:capture.dst.ip:text}
+            dstport: %{INT:capture.dst.port:text}
             \~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~
             %{GREEDYDATA:message}
         sip:


### PR DESCRIPTION
1. Use the same field name `capture.*` in heplify and kamailio sipdump in case of multiple capture tools are running to harvest SIP packets. (We'll need to concatenate those SIP packets via the same field name)
2. Make some fields from `sorted` to `text` to reduce unnecessary cost.