### PR TITLE
fix sipdump pattern

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/kamailio.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/kamailio.yml
@@ -33,7 +33,6 @@
         grok:
           type: grok
           pattern: |-
-            \|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|
             ====================
             tag: %{WORD:tag:meta}
             pid: %{NUMBER:pid:int}
@@ -45,12 +44,13 @@
             srcport: %{INT:src-port:text}
             dstip: %{IPORHOST:dst-ip:text}
             dstport: %{INT:dst-port:text}
-            \~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~
+            \~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~\~
             %{GREEDYDATA:message}
+            \|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|
         sip:
           type: sip
           sortedFields: call-id,user-agent
-  multiline.pattern: '^\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|\|'
+  multiline.pattern: '^===================='
   multiline.negate: true
   multiline.match: after
   close_inactive: 90s


### PR DESCRIPTION
1. Add missing `\~`
2. According to the source code, the dumps data should start with `====================` and end with `||||||||||||||||||||`. Ref: https://github.com/kamailio/kamailio/blob/master/src/modules/sipdump/sipdump_mod.c#L209-L222

Tested on the web UI.