### PR TITLE
fix aws eks script -- node number issue on default large cluster setup

### DIFF
--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -273,6 +273,10 @@ setup_dashbase() {
          dashbase-installation/deployment-tools/dashbase-installer-smallsetup_helm3.sh --platform=aws
       fi
     elif [ "$CLUSTERSIZE" == "large" ]; then
+      if [ "$NODENUM" -eq "2" ]; then
+         log_info "Change default node number from 2 to 3"
+         NODENUM=3
+      fi
       if [ "$SETUP_TYPE" == "ingress" ]; then
          log_info "Dashbase large setup with ingress controller endpoint is selected"
          dashbase-installation/dashbase-installer.sh --platform=aws --ingress --ingress --subdomain=$SUBDOMAIN

--- a/aws_eks_dashbase_install_w_helm2.sh
+++ b/aws_eks_dashbase_install_w_helm2.sh
@@ -235,6 +235,10 @@ setup_dashbase() {
          dashbase-installation/deployment-tools/dashbase-installer-smallsetup_helm2.sh --platform=aws
       fi
     elif [ "$CLUSTERSIZE" == "large" ]; then
+      if [ "$NODENUM" -eq "2" ]; then
+         log_info "Change default node number from 2 to 3"
+         NODENUM=3
+      fi
       if [ "$SETUP_TYPE" == "ingress" ]; then
          log_info "Dashbase large setup with ingress controller endpoint is selected"
          dashbase-installation/dashbase-installer_helm2.sh --platform=aws --ingress --ingress --subdomain=$SUBDOMAIN


### PR DESCRIPTION
The issue in this PR is caused from change the default cluster node number from 3 to 2 in small setup.. 

changes in this PR

update aws eks script in large cluster size setup, change default node number from 2 to 3


