### PR TITLE
updated admin pod; remove unnecessary dashbase values yaml file

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -333,6 +333,8 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "chmod a+x /data/*.sh"
+  # create sym link for dashbase custom values yaml from /dashbase
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "ln -s /data/dashbase-values.yaml  /dashbase/dashbase-values.yaml"
 }
 
 update_dashbase_valuefile() {

--- a/deployment-tools/config/admindash-sts_helm3.yaml
+++ b/deployment-tools/config/admindash-sts_helm3.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: dashadmin
       containers:
         - name: admindash
-          image: rluiarch/dashbase-admin:1.4
+          image: rluiarch/dashbase-admin:1.5
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash","-c","while true; do sleep 1000; done"]
           ports:

--- a/deployment-tools/dashbase-admin/Dockerfile
+++ b/deployment-tools/dashbase-admin/Dockerfile
@@ -46,7 +46,7 @@ ADD validate-license.py /dashbase
 RUN chmod +x /dashbase/validate-license.py
 
 COPY requirements.txt /dashbase
-COPY dashbase-values.yaml /dashbase
+# COPY dashbase-values.yaml /dashbase
 
 RUN pip install -r /dashbase/requirements.txt
 

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -333,6 +333,8 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_small_nolicx.tar https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase_setup_small_nolicx.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_small_nolicx.tar -C /data/"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "chmod a+x /data/*.sh"
+  # create sym link for dashbase custom values yaml from /dashbase
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "ln -s /data/dashbase-values.yaml  /dashbase/dashbase-values.yaml"
 }
 
 update_dashbase_valuefile() {

--- a/deployment-tools/dashbase-installer-smallsetup_helm3.sh
+++ b/deployment-tools/dashbase-installer-smallsetup_helm3.sh
@@ -333,6 +333,8 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_small_nolicx.tar https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase_setup_small_nolicx.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_small_nolicx.tar -C /data/"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "chmod a+x /data/*.sh"
+  # create sym link for dashbase custom values yaml from /dashbase
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "ln -s /data/dashbase-values.yaml  /dashbase/dashbase-values.yaml"
 }
 
 update_dashbase_valuefile() {

--- a/deployment-tools/dashbase-installer-tinysetup_helm3.sh
+++ b/deployment-tools/dashbase-installer-tinysetup_helm3.sh
@@ -333,6 +333,8 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_tiny_nolicx.tar https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase_setup_tiny_nolicx.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_tiny_nolicx.tar -C /data/"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "chmod a+x /data/*.sh"
+  # create sym link for dashbase custom values yaml from /dashbase
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "ln -s /data/dashbase-values.yaml  /dashbase/dashbase-values.yaml"
 }
 
 update_dashbase_valuefile() {


### PR DESCRIPTION
Changes in this PR

Background
the admin pod "admindash-0" used in our installer script and poc setup contains unnecessary dashbase custom values yaml file, originally is planned for a template in which customer may use it. And the real or active one used in deploying dashbase is on /data  folder. And because of two custom values yaml files issue; skyswitch folk use wrong one to edit and cause upgrade problem.

-- updated admindash docker container image from the Dockerfile.
-- updated the installer script to use new admindash docker image version "1.5"
-- updated the installer script to create sym link /dashbase/dashbase-values.yaml --> /data/dashbase-values.yaml 
