### PR TITLE
not drop log.offset - needed by DB-1465

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -44,7 +44,7 @@ processors:
         - from: "agent.hostname"
           to: "hostname"
   - drop_fields:
-      fields: ["offset", "beat", "prospector", "host", "input", "log.offset", "ecs", "agent", "event"]
+      fields: ["offset", "beat", "prospector", "host", "input", "ecs", "agent", "event"]
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.


### PR DESCRIPTION
filebeat version in dashbase-installation is 7.x so dropping 'offset' but keeping 'log.offset'