### PR TITLE
add user-agent field for freeswitch cdr logs

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/freeswitch.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/freeswitch.yml
@@ -49,3 +49,11 @@
   clean_removed: true
   fields:
     type: cdr
+
+  processors:
+    - copy_fields:
+        fields:
+          - from: variables.sip_user_agent
+            to: user-agent
+        fail_on_error: false
+        ignore_missing: true


### PR DESCRIPTION
Unitize SIP and CDR logs to have the same user agent field name.

(This field is used by exporter to draw metrics.