### PR TITLE
DB-1603 fix filebeat metrics collection due to curl issue in cronjob

### DIFF
--- a/log-collection/ansible/roles/telegraf/tasks/Debian.yml
+++ b/log-collection/ansible/roles/telegraf/tasks/Debian.yml
@@ -67,7 +67,7 @@
 - name: Create Prometheus pushgateway crontab
   cron:
     name: "telegraf pushgateway"
-    job: "curl -s {{ prometheus_local_exporter_url }} | curl --connect-timeout 10 --data-binary @- {{ prometheus_pushgateway_url }} &> /dev/null"
+    job: "curl -s {{ prometheus_local_exporter_url }} | curl -k --connect-timeout 10 --data-binary @- {{ prometheus_pushgateway_url }} &> /dev/null"
   when:
     - prometheus_pushgateway_enable
 

--- a/log-collection/ansible/roles/telegraf/tasks/RedHat.yml
+++ b/log-collection/ansible/roles/telegraf/tasks/RedHat.yml
@@ -80,6 +80,6 @@
 - name: Create Prometheus pushgateway crontab
   cron:
     name: "telegraf pushgateway"
-    job: "curl -s {{ prometheus_local_exporter_url }} | curl --connect-timeout 10 --data-binary @- {{ prometheus_pushgateway_url }} &> /dev/null"
+    job: "curl -s {{ prometheus_local_exporter_url }} | curl -k --connect-timeout 10 --data-binary @- {{ prometheus_pushgateway_url }} &> /dev/null"
   when:
     - prometheus_pushgateway_enable


### PR DESCRIPTION
Changes in this PR
modify the ansible playbook regarding implement cronjob to send metrics to pushgateway using curl. since pushgateway may be secured by fake cert, then we update the 2nd curl command with "-k" options

changed on RedHat.yml  and Debian.yml