### PR TITLE
DB-1455 update large size cpu, memory and java options in custom dash…

### DIFF
--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-basicauth.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-basicauth.yaml
@@ -26,13 +26,13 @@ default:
     containerConfig:
       resources:
         requests:
-          cpu: 7.3
-          memory: 26G
+          cpu: 7.5
+          memory: 60G
         limits:
           cpu: 7.5
-          memory: 28G
+          memory: 60G
     environment:
-      JAVA_OPTS: "-Xmx20g -Xms16g"
+      JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
       RETENTION_NUM_DAYS: "14"

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -29,13 +29,13 @@ default:
     containerConfig:
       resources:
         requests:
-          cpu: 7.3
-          memory: 26G
+          cpu: 7.5
+          memory: 60G
         limits:
           cpu: 7.5
-          memory: 28G
+          memory: 60G
     environment:
-      JAVA_OPTS: "-Xmx20g -Xms16g"
+      JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
       RETENTION_NUM_DAYS: "14"

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
@@ -26,13 +26,13 @@ default:
     containerConfig:
       resources:
         requests:
-          cpu: 7.3
-          memory: 26G
+          cpu: 7.5
+          memory: 60G
         limits:
           cpu: 7.5
-          memory: 28G
+          memory: 60G
     environment:
-      JAVA_OPTS: "-Xmx20g -Xms16g"
+      JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
       RETENTION_NUM_DAYS: "14"


### PR DESCRIPTION
changes in this PR for DB-1455

updated the large setup in the standard prod deployment, using the dashbase-installer.sh script for the v1 table pod: cpu , memory and java options on Xmx and Xms  as below 

    containerConfig:
      resources:
        requests:
          cpu: 7.5
          memory: 60G
        limits:
          cpu: 7.5
          memory: 60G
    environment:
      JAVA_OPTS: "-Xmx20g -Xms20g"


 changed three custom value yaml files

- dashbase-values.yaml file is for existing v1 <-- that support basic auth
- dashbase-values-basicauth.yaml  is not needed.. but keep until 1.5 in case some customer using the previous installer script.
- dashbase-values-v2.yaml support v1 and v2 and eventually will merge(replace) into dashbase-values.yaml file on 1.5  

