### PR TITLE
Added telegraf deployment yaml files  relates to DB-1144

### DIFF
--- a/deployment-tools/telegraf-deployment-set/telegraf-config.yaml
+++ b/deployment-tools/telegraf-deployment-set/telegraf-config.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+
+kind: ConfigMap
+metadata:
+  name: telegraf-config
+data:
+  telegraf.conf: |+
+    # Telegraf Configuration
+    #
+    # Telegraf is entirely plugin driven. All metrics are gathered from the
+    # declared inputs, and sent to the declared outputs.
+    #
+    # Plugins must be declared in here to be active.
+    # To deactivate a plugin, comment out the name and any variables.
+    #
+    # Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+    # file would generate.
+    #
+    # Environment variables can be used anywhere in this config file, simply prepend
+    # them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
+    # for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+
+
+    # Global tags can be specified here in key="value" format.
+    [global_tags]
+
+    # Configuration for telegraf agent
+    [agent]
+      ## Default data collection interval for all inputs
+      interval = "10s"
+      ## Rounds collection interval to 'interval'
+      ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+      round_interval = true
+
+      ## Telegraf will send metrics to outputs in batches of at most
+      ## metric_batch_size metrics.
+      ## This controls the size of writes that Telegraf sends to output plugins.
+      metric_batch_size = 1000
+
+      ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+      ## output, and will flush this buffer on a successful write. Oldest metrics
+      ## are dropped first when this buffer fills.
+      ## This buffer only fills when writes fail to output plugin(s).
+      metric_buffer_limit = 10000
+
+      ## Collection jitter is used to jitter the collection by a random amount.
+      ## Each plugin will sleep for a random time within jitter before collecting.
+      ## This can be used to avoid many plugins querying things like sysfs at the
+      ## same time, which can have a measurable effect on the system.
+      collection_jitter = "0s"
+
+      ## Default flushing interval for all outputs. Maximum flush_interval will be
+      ## flush_interval + flush_jitter
+      flush_interval = "10s"
+      ## Jitter the flush interval by a random amount. This is primarily to avoid
+      ## large write spikes for users running a large number of telegraf instances.
+      ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+      flush_jitter = "0s"
+
+      ## By default or when set to "0s", precision will be set to the same
+      ## timestamp order as the collection interval, with the maximum being 1s.
+      ##   ie, when interval = "10s", precision will be "1s"
+      ##       when interval = "250ms", precision will be "1ms"
+      ## Precision will NOT be used for service inputs. It is up to each individual
+      ## service input to set the timestamp at the appropriate precision.
+      ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+      precision = ""
+
+      ## Logging configuration:
+      ## Run telegraf with debug log messages.
+      debug = false
+      ## Run telegraf in quiet mode (error log messages only).
+      quiet = false
+      ## Specify the log file name. The empty string means to log to stderr.
+      logfile = ""
+
+      ## Override default hostname, if empty use os.Hostname()
+      hostname = "telegraf-deployment-set"
+      ## If set to true, do no set the "host" tag in the telegraf agent.
+      omit_hostname = false
+
+
+    ###############################################################################
+    #                            OUTPUT PLUGINS                                   #
+    ###############################################################################
+
+    # Configuration for sending metrics to wavefront proxy
+    [[outputs.wavefront]]
+      ## Multiple URLs can be specified for a single cluster, only ONE of the
+      ## urls will be written to each interval.
+      # urls = ["unix:///var/run/influxdb.sock"]
+      # urls = ["udp://127.0.0.1:8089"]
+      # urls = ["http://127.0.0.1:8086"]
+      #
+      #files = ["stdout"]
+      #data_format = "influx"
+      host = "wavefront-proxy.dashbase.svc.cluster.local"
+      port = 2878
+      metric_separator = "."
+      source_override = ["hostname", "agent_host", "node_host"]
+      convert_paths = true
+      use_regex = false
+
+    ###############################################################################
+    #                            INPUT PLUGINS                                    #
+    ###############################################################################
+
+    # Read metrics about cpu usage
+    [[inputs.prometheus]]
+      urls = ["http://prometheus.dashbase.svc.cluster.local:9090/federate?match[]={__name__=~%22dashbase:.*%22}"]
+      metric_version = 2

--- a/deployment-tools/telegraf-deployment-set/telegraf-deployment.yaml
+++ b/deployment-tools/telegraf-deployment-set/telegraf-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telegraf-deployment
+spec:
+  selector:
+    matchLabels:
+      app: telegraf
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: telegraf
+    spec:
+      containers:
+        - image: telegraf:1.14.0
+          name: telegraf
+          volumeMounts:
+            - mountPath: /etc/telegraf/telegraf.conf
+              name: telegraf-config
+              subPath: telegraf.conf
+              readOnly: true
+      volumes:
+        - name: telegraf-config
+          configMap:
+            name: telegraf-config


### PR DESCRIPTION
Changes in this PR 

1. Added a telegraf deployment set yaml files; and the telegraf deployment set is particular configured with  

inputs -->  prometheus:9090/federate (contains dashbase key metrics)
outputs -->  wavefront proxy 

use this telegraf deployment set is primarily want to ship the dashbase key metrics time series data from prometheus to external analytic dashboard 

No other files are affected or changed besides the added file in this PR