### PR TITLE
remove copy_fields processor

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/freeswitch.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/freeswitch.yml
@@ -49,11 +49,3 @@
   clean_removed: true
   fields:
     type: cdr
-
-  processors:
-    - copy_fields:
-        fields:
-          - from: variables.sip_user_agent
-            to: user-agent
-        fail_on_error: false
-        ignore_missing: true


### PR DESCRIPTION
remove the copy processor as our urldecode pipeline can decode from `variables.sip_user_agent` directly.