### PR TITLE
updated dashbase-values.yaml file for retention days 

### DIFF
--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -38,7 +38,7 @@ default:
       JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
-      RETENTION_NUM_DAYS: "14"
+      RETENTION_NUM_DAYS: "7"
       RETENTION_SIZE_GB: "2500"
       IN_MEMORY_BUFFER: "true"
       READER_CACHE_MEM_PERCENT: "60"
@@ -143,7 +143,7 @@ services:
           description: "ucaas unique call legs"
           table: "LOGS"
           accumulate: false
-          filter: "type:sip AND _missing_:to.tag AND method:invite"
+          filter: "type:sip"
           aggregation: "topn(hostname, 100, topn(user-agent, 100, cardinality(call-id)))"
   searcher:
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
@@ -35,7 +35,7 @@ default:
       JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
-      RETENTION_NUM_DAYS: "14"
+      RETENTION_NUM_DAYS: "7"
       RETENTION_SIZE_GB: "2500"
       IN_MEMORY_BUFFER: "true"
       READER_CACHE_MEM_PERCENT: "60"
@@ -116,6 +116,6 @@ services:
           description: "ucaas unique call legs"
           table: "LOGS"
           accumulate: false
-          filter: "type:sip AND _missing_:to.tag AND method:invite"
+          filter: "type:sip"
           aggregation: "topn(hostname, 100, topn(user-agent, 100, cardinality(call-id)))"
 

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
@@ -31,7 +31,7 @@ default:
       JAVA_OPTS: "-Xmx20g -Xms16g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
-      RETENTION_NUM_DAYS: "14"
+      RETENTION_NUM_DAYS: "7"
       RETENTION_SIZE_GB: "850"
       IN_MEMORY_BUFFER: "true"
       READER_CACHE_MEM_PERCENT: "60"
@@ -143,7 +143,7 @@ services:
           description: "ucaas unique call legs"
           table: "LOGS"
           accumulate: false
-          filter: "type:sip AND _missing_:to.tag AND method:invite"
+          filter: "type:sip"
           aggregation: "topn(hostname, 100, topn(user-agent, 100, cardinality(call-id)))"
   searcher:
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
@@ -28,7 +28,7 @@ default:
       JAVA_OPTS: "-Xmx20g -Xms16g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
-      RETENTION_NUM_DAYS: "14"
+      RETENTION_NUM_DAYS: "7"
       RETENTION_SIZE_GB: "850"
       IN_MEMORY_BUFFER: "true"
       READER_CACHE_MEM_PERCENT: "60"
@@ -116,6 +116,6 @@ services:
           description: "ucaas unique call legs"
           table: "LOGS"
           accumulate: false
-          filter: "type:sip AND _missing_:to.tag AND method:invite"
+          filter: "type:sip"
           aggregation: "topn(hostname, 100, topn(user-agent, 100, cardinality(call-id)))"
 

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
@@ -31,7 +31,7 @@ default:
       JAVA_OPTS: "-Xmx20g -Xms16g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
-      RETENTION_NUM_DAYS: "14"
+      RETENTION_NUM_DAYS: "7"
       RETENTION_SIZE_GB: "850"
       IN_MEMORY_BUFFER: "true"
       READER_CACHE_MEM_PERCENT: "60"
@@ -136,7 +136,7 @@ services:
           description: "ucaas unique call legs"
           table: "LOGS"
           accumulate: false
-          filter: "type:sip AND _missing_:to.tag AND method:invite"
+          filter: "type:sip"
           aggregation: "topn(hostname, 100, topn(user-agent, 100, cardinality(call-id)))"
   searcher:
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values.yaml
@@ -28,7 +28,7 @@ default:
       JAVA_OPTS: "-Xmx20g -Xms16g"
       BLOOM_FILTER_SIZE: "400"
       MAX_BUFFER_DELAY_IN_SEC: "1000"
-      RETENTION_NUM_DAYS: "14"
+      RETENTION_NUM_DAYS: "7"
       RETENTION_SIZE_GB: "850"
       IN_MEMORY_BUFFER: "true"
       READER_CACHE_MEM_PERCENT: "60"
@@ -116,6 +116,6 @@ services:
           description: "ucaas unique call legs"
           table: "LOGS"
           accumulate: false
-          filter: "type:sip AND _missing_:to.tag AND method:invite"
+          filter: "type:sip"
           aggregation: "topn(hostname, 100, topn(user-agent, 100, cardinality(call-id)))"
 


### PR DESCRIPTION
Changes in this PR

updated dashbase-values.yaml file for stanard / poc / tiny setup for 

-- retention days to be 7
-- exporter's filter  to  be "type:sip"