### PR TITLE
update memory requirement from 60G to 52G for v1 table in standard setup

### DIFF
--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -30,10 +30,10 @@ default:
       resources:
         requests:
           cpu: 7.5
-          memory: 60G
+          memory: 52G
         limits:
           cpu: 7.5
-          memory: 60G
+          memory: 52G
     environment:
       JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
@@ -27,10 +27,10 @@ default:
       resources:
         requests:
           cpu: 7.5
-          memory: 60G
+          memory: 52G
         limits:
           cpu: 7.5
-          memory: 60G
+          memory: 52G
     environment:
       JAVA_OPTS: "-Xmx20g -Xms20g"
       BLOOM_FILTER_SIZE: "400"


### PR DESCRIPTION
changes in this PR

updated memory requirement for GCE node that has only 60GB
so v1 table memory requirement changed from 60G to 52G
