### PR TITLE
DB-1759 fix dashbase repo missing on admin pod after restarted

### DIFF
--- a/deployment-tools/config/admindash-sts_helm3.yaml
+++ b/deployment-tools/config/admindash-sts_helm3.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: dashadmin
       containers:
         - name: admindash
-          image: rluiarch/dashbase-admin:1.6
+          image: rluiarch/dashbase-admin:2.0
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash","-c","while true; do sleep 1000; done"]
           ports:

--- a/deployment-tools/dashbase-admin/Dockerfile
+++ b/deployment-tools/dashbase-admin/Dockerfile
@@ -18,7 +18,9 @@ RUN apk add --no-cache ca-certificates bash git openssh curl \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && chmod +x /usr/local/bin/helm
+    && chmod +x /usr/local/bin/helm \
+    && /usr/local/bin/helm repo add dashbase https://charts.dashbase.io \
+    && /usr/local/bin/helm repo add stable https://kubernetes-charts.storage.googleapis.com
 
 RUN pip install --upgrade pip
 
@@ -42,6 +44,7 @@ RUN apk add --update openjdk8-jre
 RUN apk add --update openssl
 RUN apk add --update coreutils
 RUN apk add --update apache2-utils
+RUN apk add --update busybox-extras
 
 ADD validate-license.py /dashbase
 RUN chmod +x /dashbase/validate-license.py

--- a/deployment-tools/dashbase-admin/docker-entrypoint.sh
+++ b/deployment-tools/dashbase-admin/docker-entrypoint.sh
@@ -14,6 +14,8 @@ fi
 curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
 unzip /tmp/awscli-bundle.zip
 /dashbase/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+/usr/local/bin/helm repo add dashbase https://charts.dashbase.io
+/usr/local/bin/helm repo add stable https://kubernetes-charts.storage.googleapis.com
 
 ln -s /usr/local/lib/dashbase/.aws /root/.aws
 


### PR DESCRIPTION
Changes in this PR

-- update admindash-sts_helm3.yaml file to use new admin pod docker image that will have persistent dashbase repo even after admin pod is restarted.

-- updated Dockerfile for admin pod
-- updated docker-entrypoint.sh file for admin pod