### PR TITLE
added cron job that runs at 0 minutes, 0 hours every day and

### DIFF
--- a/log-collection/ansible/deploy_logstash.yml
+++ b/log-collection/ansible/deploy_logstash.yml
@@ -19,9 +19,7 @@
     configs_list: "{{ configs.split(',') }}"
     table: "logs"
 
-    mysql:
-      connection_string: "jdbc:mysql://localhost:3306/database"
+    netsapiens_1:
+      connection_string: "jdbc:mysql://localhost:3306/DiagDomain"
       user: "logstash"
       password: "logstash"
-      table: "table_name"
-      schedule: "*/10 * * * *"

--- a/log-collection/ansible/roles/logstash/tasks/main.yml
+++ b/log-collection/ansible/roles/logstash/tasks/main.yml
@@ -64,6 +64,13 @@
     group: logstash
     mode: 0600
 
+- name: Change User of logstash config directory
+  file:
+    path: /etc/logstash/conf.d
+    owner: logstash
+    group: logstash
+    mode: 0755
+
 - name: Stop Logstash Service
   service:
     name: logstash
@@ -77,3 +84,17 @@
   service:
     name: logstash
     state: started
+
+- name: Create mysql_statement file
+  shell: |-
+    echo "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM event_$(date +\%Y\%m\%d) WHERE event_type='responder' AND event_index > :sql_last_value">/etc/logstash/conf.d/netsapiens_mysql_statement
+  when: "'netsapiens' in configs_list"
+
+- name: Create cron job to update mysql statement based on current date
+  cron:
+    name: "logstash restart with new mysql_statement"
+    minute: "0"
+    hour: "0"
+    job: |-
+      systemctl stop logstash; rm /etc/logstash/conf.d/.logstash_jdbc_last_run*; echo "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM event_$(date +\%Y\%m\%d) WHERE event_type='responder' AND event_index > :sql_last_value">/etc/logstash/conf.d/netsapiens_mysql_statement; systemctl start logstash
+  when: "'netsapiens' in configs_list"

--- a/log-collection/ansible/roles/logstash/templates/configs/netsapiens.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/netsapiens.logstash.conf.j2
@@ -3,11 +3,12 @@ input {
 		jdbc_driver_library => "/usr/share/java/mysql-connector-java-8.0.19.jar"
 		jdbc_driver_class => "com.mysql.jdbc.Driver"
 
-		jdbc_connection_string => "{{ mysql.connection_string }}"
-		jdbc_user => "{{ mysql.user}}"
-		jdbc_password => "{{ mysql.password }}"
+		jdbc_connection_string => "{{ netsapiens_1.connection_string }}"
+		jdbc_user => "{{ netsapiens_1.user}}"
+		jdbc_password => "{{ netsapiens_1.password }}"
 
-		statement => "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM {{ mysql.table }} WHERE event_type='responder' AND event_index > :sql_last_value"
+                last_run_metadata_path => "/etc/logstash/conf.d/.logstash_jdbc_last_run_netsapiens_1"
+                statement_filepath => "/etc/logstash/conf.d/netsapiens_mysql_statement"
                 schedule => "*/10 * * * *"
                 use_column_value => true
                 tracking_column => "event_index"


### PR DESCRIPTION
re-creates sql statement with the table name updated to the current date:
event_20200421, event_20200422, etc. This cron job also restarts logstash
and removes .logstash_jdbc_last_run* file so fetching starting from
first record in new table.
Restart of logstash is required for jdbc driver to re-read sql
statement to run on schedule.