### PR TITLE
DB-1953 fix upgrade script failing on certain use cases

### DIFF
--- a/deployment-tools/upgrade-dashbase.sh
+++ b/deployment-tools/upgrade-dashbase.sh
@@ -7,6 +7,7 @@ VERSION="undefined"
 CHARTVERSION="undefined"
 DOCKERHUB_REGISTRY="https://registry.hub.docker.com/v2/repositories/dashbase/api/tags/"
 CURRENTVERSION=$(kubectl exec -it admindash-0 -n dashbase -- kubectl get pods/web-0 -n dashbase  -o jsonpath='{.spec.containers[*].image}' |cut -d":" -f2)
+OLDREVISION=$(kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $3}')
 
 function log_info() {
   echo -e "INFO *** $*"
@@ -25,6 +26,15 @@ function log_fatal() {
 function fail_if_empty() {
   [[ -z "$2" ]] && log_fatal "Parameter $1 must have a value."
   return 0
+}
+
+function run_check() {
+  if [[ "$NEWREVISION" != "$OLDREVISION" ]] && [[ "$USTATUS" == "deployed" ]]; then
+    log_info "SUCCESS: $*"
+    log_info "SUCCESS: dashbase is upgraded"
+  else
+    log_fatal "FAILURE: $*"
+  fi
 }
 
 function run_catch() {
@@ -73,7 +83,6 @@ backup_values_yaml() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "cp /data/dashbase-values.yaml /data/backup_values_yaml/dashbase-values_$(date +%d-%m-%Y_%H-%M-%S)_$HELM_VERSION.yaml"
 }
 
-
 update_license() {
   # check and udpate license information
   if [[ "$USERNAME" == "undefined" && "$LICENSE" == "undefined" ]]; then
@@ -97,13 +106,9 @@ update_license() {
 }
 
 check_version() {
-  #CURRENTVERSION=$(kubectl exec -it admindash-0 -n dashbase -- kubectl get pods/web-0 -n dashbase  -o jsonpath='{.spec.containers[*].image}' |cut -d":" -f2)
   if [ "$VERSION" == "undefined" ]; then
     log_info "No input dashbase version, no change in dashbase version"
     VERSION=$CURRENTVERSION
-    # update dashbase value yaml file for version string
-    # kubectl exec -it admindash-0 -n dashbase -- bash -c "sed -i '/^dashbase_version:/d' /data/dashbase-values.yaml"
-    # kubectl exec -it admindash-0 -n dashbase -- sed -i "1 i\dashbase_version: $VERSION" /data/dashbase-values.yaml
   else
     log_info "Dashbase version entered is $VERSION"
     # checking input version is valid or not
@@ -132,32 +137,62 @@ check_version() {
 # Check chart version
 # if chart version is not provided, then will use whatever previously is used
 check_chart_version() {
+kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
 chart_version=$(kubectl exec -it admindash-0 -n dashbase -- helm ls |grep '^dashbase' |awk '{print $10}')
+FINDCHART=$(kubectl exec -it admindash-0 -n dashbase --  helm search repo dashbase --devel -l |grep -iv "dashbase/dashbase-" |grep "dashbase/dashbase" |grep -iv 0.0.0.0 |grep -c "$VERSION")
+FINDCHARTX=$(kubectl exec -it admindash-0 -n dashbase --  helm search repo dashbase --devel -l |grep -iv "dashbase/dashbase-" |grep "dashbase/dashbase" |grep -iv 0.0.0.0 |grep -c "$CHARTVERSION")
+STABLECHART=$(kubectl exec -it admindash-0 -n dashbase -- helm search repo dashbase -l |sed -e 1d |head -1 |awk '{print $2}')
 
+# Case 1 user has not entered any chart version and dashbase version
 if [[ "$CHARTVERSION" == "undefined" ]] && [[ "$VERSION" == "undefined" ]]; then
   echo "Both dashbase version and chart version are not provided"
   echo "checking previous chart version is used in the deployment"
   if [[ $chart_version == \>* ]]; then
     echo "current chart version is using latest devel, and will continue using devel chart version"
+    # Case 1A  no chart version entered and will use current  devel version
     chartver="--devel"
   else
     echo "current chart version is $chart_version"
     echo "will use current chart version $chart_version"
+    # Case 1B  no chart version entered and will use current non devel version
     chartver="--version $chart_version"
   fi
+# Case 2 user has not entered any chart version but specify dashbase version
 elif [[ "$CHARTVERSION" == "undefined" ]] && [[ "$VERSION" != "undefined"  ]]; then
   echo "Dashbase version is provided and chart version is not provided"
-  echo "Both dashbase version and chart version will be in version $VERSION"
-  chartver="--version $VERSION"
+  echo "Finding the corresponding chart version $VERSION in dashbase helm repo"
+  if [ "$FINDCHART" == "0" ]; then
+    log_info "There is no dashbase chart version for $VERSION"
+    log_info "This upgrade will use latest stable chart version $STABLECHART"
+    # Case 2A no chart version entered and no matching dashbase version in dashbase helm repo, will use latest stable chart version
+    chartver="--version $STABLECHART"
+  else
+    log_info "The dashbase chart version for $VERSION is found"
+    # Case 2B no chart version entered but found matching dashbase version in dashbase helm repo, will use matched dashbase version for chart version
+    chartver="--version $VERSION"
+  fi
+# Case 3 user want to use latest devel chart version
 elif [[ "$CHARTVERSION" == "devel" ]]; then
   echo "Entered chart version is latest development version"
   chartver="--devel"
+
+# Case 4 user want to use current chart version
 elif [[ "$CHARTVERSION" == "current" ]]; then
   echo "Entered chart version is using current version $chart_version"
   chartver="--version $chart_version"
+
+# Case 5 user enetered chart version
 elif [[ "$CHARTVERSION" != "undefined" ]]; then
   echo "Entered chart version is $CHARTVERSION"
-  chartver="--version $CHARTVERSION"
+  echo "Checking entered chart version in dashbae helm repo"
+  if [ "$FINDCHARTX" == "0" ]; then
+    log_info "There is no dashbase chart version for entered chart version $CHARTVERSION"
+    log_info "This upgrade will use latest stable chart version $STABLECHART"
+    chartver="--version $STABLECHART"
+  else
+    log_info "The dashbase chart version for $CHARTVERSION is found"
+    chartver="--version $CHARTVERSION"
+  fi
 fi
 }
 
@@ -173,17 +208,24 @@ if [ "$VALUEFILE" == "dashbase-values.yaml" ]; then
   update_license
   check_version
   check_chart_version
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm upgrade dashbase dashbase/dashbase -f /data/dashbase-values.yaml --namespace dashbase $chartver &> /dev/null"
-  run_catch "helm upgrade dashbase dashbase/dashbase -f /data/dashbase-values.yaml --namespace dashbase $chartver"
+  kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $1,$3,$8,$9,$10}'
+  NEWREVISION=$(kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $3}')
+  USTATUS=$(kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $8}')
+  run_check "helm upgrade dashbase dashbase/dashbase -f /data/dashbase-values.yaml --namespace dashbase $chartver"
 else
   log_info "using custom dashbase value file $VALUEFILE"
   kubectl cp "$VALUEFILE" dashbase/admindash-0:/data/
   DASHVALUEFILE=$(echo $VALUEFILE | rev | cut -d"/" -f1 | rev)
   check_chart_version
-  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm upgrade dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase $chartver > /dev/null"
-  run_catch "helm upgrade dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase $chartver"
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm upgrade dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase $chartver &> /dev/null"
+  kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $1,$3,$8,$9,$10}'
+  NEWREVISION=$(kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $3}')
+  USTATUS=$(kubectl exec -it admindash-0 -n dashbase -- helm ls -n dashbase |sed -e 1d |grep -iv ingress |awk '{print $8}')
+  run_check "helm upgrade dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase $chartver"
 fi
-
 
 # Force restart api pod when upgrade license only and no dashbase version change
 if [[ "$LICENSE" != "undefined" || "$USERNAME" != "undefined" ]] && [[ "$VERSION" == "$CURRENTVERSION" ]]; then

--- a/deployment-tools/upgrade-dashbase.sh
+++ b/deployment-tools/upgrade-dashbase.sh
@@ -188,9 +188,11 @@ elif [[ "$CHARTVERSION" != "undefined" ]]; then
   if [ "$FINDCHARTX" == "0" ]; then
     log_info "There is no dashbase chart version for entered chart version $CHARTVERSION"
     log_info "This upgrade will use latest stable chart version $STABLECHART"
+    # Case 5A user entered chart version but is not found in dashbase helm repo, then will use latest stable chart version
     chartver="--version $STABLECHART"
   else
     log_info "The dashbase chart version for $CHARTVERSION is found"
+    # Case 5B user entered chart version and is found on dashbase helm repo, will use entered chart version
     chartver="--version $CHARTVERSION"
   fi
 fi


### PR DESCRIPTION
Changes in this PR is to fix the upgrade script failing in certain use cases.

1. Added "helm repo update" before running the helm upgrade command.
2. New chart version checking logic.. usually when we do helm upgrade we usually don't specify --version and automatically it will use the latest stable chart version"

The following is the logic to determine the dashbase chart version

`Case 1 user has not entered any chart version and dashbase version
  Case 1A  no chart version entered and will use current  devel version
  Case 1B  no chart version entered and will use current non devel version

Case 2 user has not entered any chart version but specify dashbase version
  Case 2A no chart version entered and no matching dashbase version in dashbase helm repo, will use latest stable chart version
  Case 2B no chart version entered but found matching dashbase version in dashbase helm repo, will use matched dashbase version for chart version

Case 3 user want to use latest devel chart version

Case 4 user want to use current chart version

Case 5 user enetered chart version
  Case 5A user entered chart version but is not found in dashbase helm repo, then will use latest stable chart version
  Case 5B user entered chart version and is found on dashbase helm repo, will use entered chart version`


3. update the helm upgrade check which will look for helm revision and status.  In most case helm will increment the revision. But if revision is not incremented, that means helm upgrade can't be run. And even helm upgrade can be run, it will also in failed or crashed stated, the normal state is deployed.

