### PR TITLE
Update installer script to support --version=2.x.x to install V2 

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -19,6 +19,7 @@ TABLENAME="logs"
 CDR_FLAG="false "
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
+VNUM=$(echo $DASHVERSION |cut -d "." -f1)
 
 echo "Installer script version is $INSTALLER_VERSION"
 
@@ -378,22 +379,21 @@ check_basic_auth() {
 
 check_v2() {
   # check v2 input
-  if [ "$V2_FLAG" ==  "true" ] && [ "$BUCKETNAME" == "undefined" ]; then
-    log_fatal "V2 is selected but not provide any cloud object storage bucket name"
-  elif [ "$V2_FLAG" ==  "true" ] &&  [ "$BUCKETNAME" != "undefined" ]; then
-    log_info "V2 is selected and bucket name is $BUCKETNAME"
-  elif [ "$V2_FLAG" ==  "true" ] && [ "$PLATFORM" == "gce" ]; then
-    log_info "V2 is selected and cloud platform is gce"
-    if [ "$STORAGE_ACCOUNT" == "undefined" ] || [ "$STORAGE_KEY" == "undefined" ]; then
-      log_fatal "V2 setup on GCE requires inputs for --storage_account and --storage_key"
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
+    log_info "V2 is selected checking V2 requirement"
+    if [ "$BUCKETNAME" == "undefined" ]; then
+       log_fatal "V2 is selected but not provide any cloud object storage bucket name"
+    elif [ "$BUCKETNAME" != "undefined" ]; then
+       log_info "V2 is selected and bucket name is $BUCKETNAME"
     fi
-  elif [ "$V2_FLAG" ==  "true" ] && [ "$PLATFORM" == "azure" ]; then
-    log_info "V2 is selected and cloud platform is azure"
-    if [ "$STORAGE_ACCOUNT" == "undefined" ] || [ "$STORAGE_KEY" == "undefined" ]; then
-      log_fatal "V2 setup on Azure requires inputs for --storage_account and --storage_key"
+    if [ "$PLATFORM" == "gce" ] || [ "$PLATFORM" == "azure" ]; then
+       log_info "V2 is selected and cloud platform is $PLATFORM"
+       if [ "$STORAGE_ACCOUNT" == "undefined" ] || [ "$STORAGE_KEY" == "undefined" ]; then
+          log_fatal "V2 setup on $PLATFORM requires inputs for --storage_account and --storage_key"
+       fi
     fi
-  elif [ "$V2_FLAG" ==  "false" ]; then
-    log_info "V2 is not selected in this installation"
+  elif [[ "$V2_FLAG" ==  "false" ]] && [[ ${VNUM} -eq 1 ]]; then
+      log_info "V2 is not selected in this installation"
   fi
 }
 
@@ -514,7 +514,7 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   # get the custom values yaml file
-  if [ "$V2_FLAG" == "true" ]; then
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
     log_info "Download dashbase-values-v2.yaml file for v2 setup"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase-values.yaml https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml"
   else
@@ -780,6 +780,9 @@ fi
 # expose services
 expose_endpoints
 
+# demo setup
+demo_setup
+
 # display endpoints
 echo "Exposed endpoints are below"
 
@@ -825,7 +828,5 @@ else
   done
 
 fi
-
-demo_setup
 
 } 2>&1 | tee -a /tmp/dashbase_install_"$(date +%d-%m-%Y_%H-%M-%S)".log

--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -19,7 +19,6 @@ TABLENAME="logs"
 CDR_FLAG="false "
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
-VNUM=$(echo $DASHVERSION |cut -d "." -f1)
 
 echo "Installer script version is $INSTALLER_VERSION"
 
@@ -333,6 +332,7 @@ check_version() {
       log_fatal "Entered dashbase version $VERSION is invalid"
     fi
   fi
+  VNUM=$(echo $VERSION |cut -d "." -f1)
 }
 
 check_ostype() {
@@ -514,7 +514,8 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   # get the custom values yaml file
-  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
+  echo "VNUM is $VNUM"
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
     log_info "Download dashbase-values-v2.yaml file for v2 setup"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase-values.yaml https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml"
   else
@@ -589,7 +590,7 @@ update_dashbase_valuefile() {
     kubectl exec -it admindash-0 -n dashbase -- sed -i '/prometheus\_env\_variable/ r /data/prometheus_webrtc' /data/dashbase-values.yaml
   fi
   # update bucket name and storage access
-  if [ "$V2_FLAG" == "true" ]; then
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
     log_info "update object storage bucket name"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "sed -i 's|MYBUCKET|$BUCKETNAME|' /data/dashbase-values.yaml"
 

--- a/deployment-tools/check-K8s-cpu-memory.sh
+++ b/deployment-tools/check-K8s-cpu-memory.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+NODES=$(kubectl get nodes |sed -e 1d |awk '{print $1}' |tr '\n' ' ')
+#echo $NODES
+
+for ND in $NODES ; do
+   #echo $ND
+   CPU=$(kubectl describe node $ND |grep "cpu\:" |tail -1 |awk '{ print $2}' |sed -e 's/m//g')
+   MEM=$(kubectl describe node $ND |grep "memory\:" |tail -1 |awk '{ print $2}' |sed -e 's/Ki//g')
+   #echo $CPU
+   #echo $((MEM / (1024*1024))) | sed 's/..$/.&/'
+   sumcpu=$(($sumcpu + $CPU))
+   summem=$(($summem + $MEM))
+
+done
+
+TMEMGI=$((summem / (1024*1024)))
+echo "Total K8s cluster allowed CPU to use: ${sumcpu}m"
+echo "Total K8s cluster allowed Memory to use: ${TMEMGI}Gi"

--- a/deployment-tools/check-K8s-nodes-resources-usage.sh
+++ b/deployment-tools/check-K8s-nodes-resources-usage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+NODES=$(kubectl get nodes |sed -e 1d |awk '{print $1}' |tr '\n' ' ')
+
+for ND in $NODES ; do
+   echo $ND
+   kubectl describe node $ND  |grep -E "cpu|memory" |grep -ivE "cpu\:|memory\:" |grep -iv MemoryPressure
+done

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -19,6 +19,7 @@ TABLENAME="logs"
 CDR_FLAG="false "
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
+VNUM=$(echo $DASHVERSION |cut -d "." -f1)
 
 echo "Installer script version is $INSTALLER_VERSION poc setup"
 
@@ -378,22 +379,21 @@ check_basic_auth() {
 
 check_v2() {
   # check v2 input
-  if [ "$V2_FLAG" ==  "true" ] && [ "$BUCKETNAME" == "undefined" ]; then
-    log_fatal "V2 is selected but not provide any cloud object storage bucket name"
-  elif [ "$V2_FLAG" ==  "true" ] &&  [ "$BUCKETNAME" != "undefined" ]; then
-    log_info "V2 is selected and bucket name is $BUCKETNAME"
-  elif [ "$V2_FLAG" ==  "true" ] && [ "$PLATFORM" == "gce" ]; then
-    log_info "V2 is selected and cloud platform is gce"
-    if [ "$STORAGE_ACCOUNT" == "undefined" ] || [ "$STORAGE_KEY" == "undefined" ]; then
-      log_fatal "V2 setup on GCE requires inputs for --storage_account and --storage_key"
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
+    log_info "V2 is selected checking V2 requirement"
+    if [ "$BUCKETNAME" == "undefined" ]; then
+       log_fatal "V2 is selected but not provide any cloud object storage bucket name"
+    elif [ "$BUCKETNAME" != "undefined" ]; then
+       log_info "V2 is selected and bucket name is $BUCKETNAME"
     fi
-  elif [ "$V2_FLAG" ==  "true" ] && [ "$PLATFORM" == "azure" ]; then
-    log_info "V2 is selected and cloud platform is azure"
-    if [ "$STORAGE_ACCOUNT" == "undefined" ] || [ "$STORAGE_KEY" == "undefined" ]; then
-      log_fatal "V2 setup on Azure requires inputs for --storage_account and --storage_key"
+    if [ "$PLATFORM" == "gce" ] || [ "$PLATFORM" == "azure" ]; then
+       log_info "V2 is selected and cloud platform is $PLATFORM"
+       if [ "$STORAGE_ACCOUNT" == "undefined" ] || [ "$STORAGE_KEY" == "undefined" ]; then
+          log_fatal "V2 setup on $PLATFORM requires inputs for --storage_account and --storage_key"
+       fi
     fi
-  elif [ "$V2_FLAG" ==  "false" ]; then
-    log_info "V2 is not selected in this installation"
+  elif [[ "$V2_FLAG" ==  "false" ]] && [[ ${VNUM} -eq 1 ]]; then
+      log_info "V2 is not selected in this installation"
   fi
 }
 
@@ -780,6 +780,9 @@ fi
 # expose services
 expose_endpoints
 
+# demo setup
+demo_setup
+
 # display endpoints
 echo "Exposed endpoints are below"
 
@@ -825,7 +828,5 @@ else
   done
 
 fi
-
-demo_setup
 
 } 2>&1 | tee -a /tmp/dashbase_install_"$(date +%d-%m-%Y_%H-%M-%S)".log

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -514,7 +514,7 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   # get the custom values yaml file
-  if [ "$V2_FLAG" == "true" ]; then
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
     log_info "Download dashbase-values-v2.yaml file for v2 setup"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase-values.yaml https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml"
   else

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -19,7 +19,6 @@ TABLENAME="logs"
 CDR_FLAG="false "
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
-VNUM=$(echo $DASHVERSION |cut -d "." -f1)
 
 echo "Installer script version is $INSTALLER_VERSION poc setup"
 
@@ -333,6 +332,7 @@ check_version() {
       log_fatal "Entered dashbase version $VERSION is invalid"
     fi
   fi
+  VNUM=$(echo $VERSION |cut -d "." -f1)
 }
 
 check_ostype() {
@@ -514,7 +514,8 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   # get the custom values yaml file
-  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
+  echo "VNUM is $VNUM"
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
     log_info "Download dashbase-values-v2.yaml file for v2 setup"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase-values.yaml https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml"
   else
@@ -589,7 +590,7 @@ update_dashbase_valuefile() {
     kubectl exec -it admindash-0 -n dashbase -- sed -i '/prometheus\_env\_variable/ r /data/prometheus_webrtc' /data/dashbase-values.yaml
   fi
   # update bucket name and storage access
-  if [ "$V2_FLAG" == "true" ]; then
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
     log_info "update object storage bucket name"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "sed -i 's|MYBUCKET|$BUCKETNAME|' /data/dashbase-values.yaml"
 

--- a/deployment-tools/dashbase-installer-tinysetup.sh
+++ b/deployment-tools/dashbase-installer-tinysetup.sh
@@ -19,7 +19,6 @@ TABLENAME="logs"
 CDR_FLAG="false "
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
-VNUM=$(echo $DASHVERSION |cut -d "." -f1)
 
 echo "Installer script version is $INSTALLER_VERSION tiny setup for install testing only"
 
@@ -333,6 +332,7 @@ check_version() {
       log_fatal "Entered dashbase version $VERSION is invalid"
     fi
   fi
+  VNUM=$(echo $VERSION |cut -d "." -f1)
 }
 
 check_ostype() {
@@ -514,6 +514,7 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   # get the custom values yaml file
+  echo "VNUM is $VNUM"
   if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
     log_info "Download dashbase-values-v2.yaml file for v2 setup"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase-values.yaml https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml"
@@ -589,7 +590,7 @@ update_dashbase_valuefile() {
     kubectl exec -it admindash-0 -n dashbase -- sed -i '/prometheus\_env\_variable/ r /data/prometheus_webrtc' /data/dashbase-values.yaml
   fi
   # update bucket name and storage access
-  if [ "$V2_FLAG" == "true" ]; then
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
     log_info "update object storage bucket name"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "sed -i 's|MYBUCKET|$BUCKETNAME|' /data/dashbase-values.yaml"
 

--- a/deployment-tools/dashbase-installer-tinysetup.sh
+++ b/deployment-tools/dashbase-installer-tinysetup.sh
@@ -514,7 +514,7 @@ download_dashbase() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase_setup_nolicy.tar  https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/dashbase_setup_nolicy.tar"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "tar -xvf /data/dashbase_setup_nolicy.tar -C /data/"
   # get the custom values yaml file
-  if [ "$V2_FLAG" == "true" ]; then
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
     log_info "Download dashbase-values-v2.yaml file for v2 setup"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "wget -O /data/dashbase-values.yaml https://github.com/dashbase/dashbase-installation/raw/master/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml"
   else

--- a/deployment-tools/uninstall-dashbase.sh
+++ b/deployment-tools/uninstall-dashbase.sh
@@ -42,6 +42,34 @@ remove_storageclass() {
     fi
 }
 
+remove_demo_setup() {
+  # delete demo freeswitch pods
+  if [ "$(kubectl get deployment -n dashbase |grep -c freeswitch)" -gt "0" ]; then
+     log_info "demo freeswitch deployment sets exists"
+     for FREESW in $(kubectl get deployment -n dashbase |grep freeswitch |awk '{print $1}' |tr "\n" " "); do
+         log_info "delete deployment set $FREESW"
+         kubectl delete deployment "$FREESW" -n dashbase
+      done
+  else
+     log_info "no freeswitch deployment set is found"
+  fi
+  # delete demo filebeat / freeswitch stateful set
+  if [ "$(kubectl get sts -n dashbase |grep -c filebeat-loader)" -gt "0" ]; then
+     log_info "demo filebeat stateful set  filebeat-loader exists"
+     kubectl delete sts filebeat-loader -n dashbase
+     log_info "delete demo stateful set filebeat-loader"
+  else
+     log_info "no demo filebeat stateful set is found"
+  fi
+  if [ "$(kubectl get sts -n dashbase |grep -c freeswitch)" -gt "0" ]; then
+     log_info "demo freeswitch stateful set freeswitch exists"
+     kubectl delete sts freeswitch -n dashbase
+     log_info "delete demo stateful  set freeswitch"
+  else
+     log_info "no demo freeswitch  stateful set is found"
+  fi
+}
+
 remove_tiller() {
     #  delete helm tiller
     if [ "$(kubectl get po -n kube-system |grep -c tiller-deploy)" -gt "0" ]; then
@@ -222,6 +250,8 @@ remove_sa_dashadmin() {
 }
 
 remove_combo() {
+    # delete demo setup
+    remove_demo_setup
     # delete pvc
     delete_dashbase_pvc
     # delete secrets


### PR DESCRIPTION
Changes in this PR

The dashbase-installer.sh  (include small & tiny setup) requires to use "--v2" to define for V2 installation. However, if you use "--version=2.12" ; and it won't automatically switch to V2 installation. And this PR is to add the script logic to detect if user input "--version=2.x.x" ; and whenever the left most version number (VNUM) is greater than or equal to 2; then it automatically to switch to V2 setup instead of explicitly using "--v2" flag e.g. "--v2 --version=2.1.2" 

1. allowing "--version=2.x.x"  detection in script logic.
2. update uninstall-dashbase.sh script to remove demo "freeswitch" compoents.
3. added check K8s cpu and node resources script.

All script changes in this PR are tested.
 