### PR TITLE
updates on aws eks, uninstall, and admin pod image

### DIFF
--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -64,6 +64,8 @@ display_help() {
   echo "                              e.g. --authusername=admin"
   echo "     --authpassword           basic auth password, use together with authusername option"
   echo "                              e.g. --authpassword=dashbase"
+  echo "     --ucaas                  enable ucaas feature on dashbase installation  e.g. --ucaas"
+  echo "     --cdr                    enable cdr log data for insight page on dashbase installation  e.g. --cdr"
   echo "     --version                dashbase version e.g. --version=1.3.2"
   echo "     --v2                     setup dashbase V2, e.g.  --v2"
   echo ""
@@ -698,7 +700,7 @@ setup_dashbase() {
     echo "download dashbase software"
     /usr/bin/git clone https://github.com/dashbase/dashbase-installation.git
     echo "setup and configure dashbase, this process will take 20-30 minutes"
-    if [ "$V2_FLAG" == "true" ]; then
+    if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
       log_info "Dashbase V2 is selected"
       create_s3
       update_s3_policy_json

--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -732,6 +732,7 @@ display_bucketname() {
 run_by_root
 check_ostype
 check_commands
+check_version
 check_input
 show_setup
 check_basic_auth

--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -11,7 +11,7 @@ RANDOM=$(openssl rand -hex 3 > randomstring)
 RSTRING=$(cat randomstring)
 
 DASHVERSION="1.5.4"
-AWS_EKS_SCRIPT_VERSION="1.4.0"
+AWS_EKS_SCRIPT_VERSION="1.5.4"
 AWS_ACCESS_KEY="undefined"
 AWS_SECRET_ACCESS_KEY="undefined"
 REGION="us-east-2"
@@ -493,48 +493,48 @@ V1_dashbase() {
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --cdr --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --version=$VERSION
           fi
       elif [ "$SETUP_TYPE" == "ingress" ] && [ "$BASIC_AUTH" == "true" ]; then
          log_info "Dashbase small setup with ingress controller endpoint and basic auth is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --cdr --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --version=$VERSION
          fi
       else
          log_info "Dashbase small setup with load balancer endpoint is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --cdr --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --version=$VERSION
         fi
       fi
     elif [ "$CLUSTERSIZE" == "large" ]; then
@@ -543,48 +543,48 @@ V1_dashbase() {
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --cdr --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --version=$VERSION
          fi
       elif [ "$SETUP_TYPE" == "ingress" ] && [ "$BASIC_AUTH" == "true" ]; then
          log_info "Dashbase large setup with ingress controller endpoint and basic auth is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --cdr --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD
+           dashbase-installation/dashbase-installer.sh --platform=aws --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --version=$VERSION
          fi
       else
          log_info "Dashbase small setup with load balancer endpoint is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --cdr --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/dashbase-installer.sh --platform=aws
+           dashbase-installation/dashbase-installer.sh --platform=aws --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws
+           dashbase-installation/dashbase-installer.sh --platform=aws --version=$VERSION
          fi
       fi
     fi
@@ -597,48 +597,48 @@ V2_dashbase() {
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --cdr --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --version=$VERSION
          fi
       elif [ "$SETUP_TYPE" == "ingress" ] && [ "$BASIC_AUTH" == "true" ]; then
          log_info "Dashbase small setup with ingress controller endpoint and basic auth is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --cdr --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --version=$VERSION
         fi
       else
          log_info "Dashbase small setup with load balancer endpoint is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME --cdr --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME --ucaas
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME
+           dashbase-installation/deployment-tools/dashbase-installer-smallsetup.sh --platform=aws --v2 --bucketname=$BUCKETNAME --version=$VERSION
          fi
       fi
     elif [ "$CLUSTERSIZE" == "large" ]; then
@@ -647,48 +647,48 @@ V2_dashbase() {
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --cdr --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --bucketname=$BUCKETNAME --version=$VERSION
          fi
       elif [ "$SETUP_TYPE" == "ingress" ] && [ "$BASIC_AUTH" == "true" ]; then
          log_info "Dashbase large setup with ingress controller endpoint and basic auth is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --cdr --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --ingress --subdomain=$SUBDOMAIN --basic_auth --authusername=$AUTHUSERNAME --authpassword=$AUTHPASSWORD --bucketname=$BUCKETNAME --version=$VERSION
          fi
       else
          log_info "Dashbase small setup with load balancer endpoint is selected"
          # checking ucass and cdr flag is selected or not
          if [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "true" ]; then
            log_info "UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME --cdr --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME --cdr --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "true" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "UCASS option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME --ucaas
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME --ucaas --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "true" ]; then
            log_warning "only CDR option is selected and missing UCAAS option, will install default without UCAAS"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME --version=$VERSION
          elif [ "$UCAAS_FLAG" == "false" ] && [ "$CDR_FLAG" == "false" ]; then
            log_info "no UCAAS and CDR option is selected"
-           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME
+           dashbase-installation/dashbase-installer.sh --platform=aws --v2 --bucketname=$BUCKETNAME --version=$VERSION
          fi
       fi
     fi
@@ -742,5 +742,6 @@ check_max_vpc_limit
 setup_eks_cluster
 check_eks_cluster
 setup_dashbase
+# shellcheck disable=SC2119
 display_bucketname
 #} 2>&1 | tee -a /tmp/aws_eks_setup_"$(date +%d-%m-%Y_%H-%M-%S)".log

--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -78,7 +78,7 @@ display_help() {
   echo "                                 --authpassword=dashbase"
   echo ""
   echo "   Command example in V2"
-  echo "   ./aws_eks_dashbase_install.sh --v2 --aws_access_key=YOURAWSACCESSKEY \ "
+  echo "   ./aws_eks_dashbase_install.sh --version=2.2.1 --aws_access_key=YOURAWSACCESSKEY \ "
   echo "                                 --aws_secret_access_key=YOURACESSSECRETACCESSKEY \ "
   echo "                                 --region=us-west-2 --subdomain=test.dashase.io  \ "
   echo "                                 --install_dashbase --basic_auth\ "

--- a/deployment-tools/config/admindash-server-sts_helm3.yaml
+++ b/deployment-tools/config/admindash-server-sts_helm3.yaml
@@ -40,8 +40,7 @@ spec:
       serviceAccountName: dashadmin
       containers:
         - name: admindash
-          # TODO
-          image: dashbase/dashbase-admin:chaotest
+          image: dashbase/dashbase-admin-server:nightly
           imagePullPolicy: Always
           command: ["flask", "run", '--host=0.0.0.0']
           env:

--- a/deployment-tools/create-sslcerts.sh
+++ b/deployment-tools/create-sslcerts.sh
@@ -26,7 +26,7 @@ rm -rf ~/data/https-dashbase.yaml
 DASH_FLAG="false"
 PRESTO_FLAG="false"
 NAMESPACE="undefined"
-CMDS="curl tar unzip git"
+CMDS="curl tar unzip git keytool"
 
 # log functions and input flag setup
 function log_info() {


### PR DESCRIPTION
Changes in this PR

1. Update the aws_eks_dashbase_install.sh script to use "--version" flag instead of "--v2"
   So when deploying v2 with aws eks script, user can specify --version=2.2.1
   And by default, the script will detects what version being entered, if no version is entered, the default is 1.5.4
   From the dashbase version, the script will create the AWS EKS worker nodes accordingly:
   For V1 Poc setup, EKS nodes will be 2 X R5.xlarge
   For V1 standard setup, EKS nodes will be 2X R5.2xlarge
   For V2 Poc setup, EKS node will be 1 X C5.4xlarge
   For V2 standard setup, EKS nodes will be 2X C5.4xlarge

2. updated the dashbase uninstall script to remove previous created K8s cluster role, and role bindings via dashbase helm install and installation script.

3. updated admindash-server-sts-helm3.yaml file for the admindash docker image  to dashbase/dashbase-admin-server:nightly . This one has the CSS fix when viewing the node description.