### PR TITLE
change admin pod image back to previous version

### DIFF
--- a/deployment-tools/config/admindash-server-sts_helm3.yaml
+++ b/deployment-tools/config/admindash-server-sts_helm3.yaml
@@ -40,7 +40,8 @@ spec:
       serviceAccountName: dashadmin
       containers:
         - name: admindash
-          image: dashbase/dashbase-admin-server:nightly
+          image: dashbase/dashbase-admin:chaotest
+          # image: dashbase/dashbase-admin-server:nightly
           imagePullPolicy: Always
           command: ["flask", "run", '--host=0.0.0.0']
           env:


### PR DESCRIPTION
Roll back changes on admin pod image 

from latest 
    dashbase/dashbase-admin-server:nightly
to previous 
   dashbase/dashbase-admin:chaotest

Because the latest image is missing some env variables, keytool, and openssl package which cause errors when running dashbase installation.


