### PR TITLE
DB-2259 fix sascdr date pattern

### DIFF
--- a/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
@@ -27,7 +27,7 @@ filter {
     }
   }
   date {
-    match => ["time_start", "UNIX"]
+    match => ["time_start", "ISO8601", "yyyy-MM-dd HH:mm:ss"]
   }
 }
 


### PR DESCRIPTION
Added two patterns here because `time_start` is `2020-07-14T08:46:48.000Z` on demo cluster, but become `2020-07-14 08:46:48` on sample logs.