### PR TITLE
DB-1855 add scripts to migrate templates data from etcd-operator to incubator…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 inventory
 
 logstash-oss-7.6.1.deb
+
+# ETCD backup tool
+etcd-templates-backup.json
+generated/

--- a/deployment-tools/dashbase-admin/Dockerfile
+++ b/deployment-tools/dashbase-admin/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC
 
 RUN apk update && apk upgrade
 
-RUN apk add --no-cache ca-certificates bash git openssh curl \
+RUN apk add --no-cache ca-certificates bash git openssh curl jq \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \

--- a/deployment-tools/dashbase-admin/tools/etcd/backup-etcd-templates.sh
+++ b/deployment-tools/dashbase-admin/tools/etcd/backup-etcd-templates.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# required commands
+# - jq
+# - kubectl
+# - curl
+# - base64
+
+if [ "$(kubectl get po -l app=etcd,etcd_cluster=etcd-cluster -o json | jq '.items | length')" -eq 0 ]; then
+  echo "No living ETCD-Operator pod found."
+  exit 0
+fi
+
+ETCD_OPERATOR_PODNAME=$(kubectl get po -l app=etcd,etcd_cluster=etcd-cluster -o json | jq -r '.items[0].metadata.name')
+
+# https://etcd.io/docs/v3.4.0/learning/api/
+ETCD_RANGE_KEY="ZGFzaGJhc2VfdGVtcGxhdGU=" # echo -n "dashbase_template" | base64
+ETCD_RANGE_END="ZGFzaGJhc2VfdGVtcGxhdGY=" # echo -n "dashbase_templatf" | base64
+
+kubectl exec -it "${ETCD_OPERATOR_PODNAME}" -- apk add curl --update
+kubectl exec -it "${ETCD_OPERATOR_PODNAME}" -- curl -L http://localhost:2379/v3beta/kv/range -X POST -d '{"key": "'$ETCD_RANGE_KEY'","range_end": "'$ETCD_RANGE_END'"}' > etcd-templates-backup.json

--- a/deployment-tools/dashbase-admin/tools/etcd/restore-etcd-templates.sh
+++ b/deployment-tools/dashbase-admin/tools/etcd/restore-etcd-templates.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# required commands
+# - jq
+# - kubectl
+
+# create tmp dir
+mkdir -p generated
+
+for kv in $(jq -c ".kvs[]" etcd-templates-backup.json); do
+  KEY=$(jq -r '.key | @base64d' <<<"$kv")
+  VALUE=$(jq -r '.value | @base64d' <<<"$kv")
+
+  echo -n $VALUE >generated/"${KEY}".json
+  kubectl cp generated/"${KEY}".json etcd-cluster-client-0:/"${KEY}".json
+  kubectl exec -it etcd-cluster-client-0 -- sh -c "cat /${KEY}.json | ETCDCTL_API=3 etcdctl put ${KEY}"
+done


### PR DESCRIPTION
…/etcd

**NOTE: The backup script only backup templates whose name starts with `dashbase_template`.**

Steps to migrate templates:
1. `cd deployment-tools/dashbase-admin/tools/etcd`
2. `./backup-etcd-templates.sh`
3. disable etcd-operator and helm upgrade
4. enable incubator and helm upgrade, remove the service `etcd-cluster-client` to hang up tables/indexers/proxies.
5. `./restore-etcd-templates.sh`
6. helm upgrade again to re-create the service.

Tested locally, but I found sometimes the table can't find newly created templates in time(not sure why yet :( ). Do we need to re-pull the templates when health checks succeed? @keitaf 