### PR TITLE
rename sas time_start

### DIFF
--- a/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
@@ -18,16 +18,17 @@ input {
 }
 
 filter {
+  date {
+    match => ["time_start", "ISO8601", "yyyy-MM-dd HH:mm:ss"]
+  }
   mutate {
     rename => {
       "orig_callid" => "call-id"
+      "time_start" => "sas_time_start"
     }
     add_field => {
       "type" => "cdr"
     }
-  }
-  date {
-    match => ["time_start", "ISO8601", "yyyy-MM-dd HH:mm:ss"]
   }
 }
 


### PR DESCRIPTION
rename `time_start` to `sas_time_start` to avoid schema flipping.