### PR TITLE
DB-2342 add template support for logstash

### DIFF
--- a/log-collection/ansible/deploy_logstash.yml
+++ b/log-collection/ansible/deploy_logstash.yml
@@ -17,7 +17,7 @@
   vars:
     logstash_version: "oss-7.6.1"
     configs_list: "{{ configs.split(',') }}"
-    table: "logs"
+    table: "logstash-logs"
 
     netsapiens_1:
       connection_string: "jdbc:mysql://localhost:3306/database"

--- a/log-collection/ansible/roles/logstash/tasks/main.yml
+++ b/log-collection/ansible/roles/logstash/tasks/main.yml
@@ -62,6 +62,15 @@
   with_items:
     "{{ configs_list }}"
 
+## Copy templates json
+- name: Copy the templates.json
+  template:
+    src: templates.json
+    dest: /etc/logstash/templates.json
+    owner: logstash
+    group: logstash
+    mode: 0600
+
 ## Copy the Logstash pipeline config file
 - name: Copy pipelines.yml file
   template:

--- a/log-collection/ansible/roles/logstash/templates/configs/nscdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/nscdr_1.logstash.conf.j2
@@ -34,6 +34,9 @@ output {
     elasticsearch {
         hosts => "{{ dashbase_url }}"
         index => "{{ table }}"
+        template => "/etc/logstash/templates.json"
+        template_name => "{{ table }}"
+        template_overwrite => true
         ssl_certificate_verification => false
     }
 }

--- a/log-collection/ansible/roles/logstash/templates/configs/nscdr_2.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/nscdr_2.logstash.conf.j2
@@ -34,6 +34,9 @@ output {
     elasticsearch {
         hosts => "{{ dashbase_url }}"
         index => "{{ table }}"
+        template => "/etc/logstash/templates.json"
+        template_name => "{{ table }}"
+        template_overwrite => true
         ssl_certificate_verification => false
     }
 }

--- a/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
@@ -36,6 +36,9 @@ output {
     elasticsearch {
         hosts => "{{ dashbase_url }}"
         index => "{{ table }}"
+        template => "/etc/logstash/templates.json"
+        template_name => "{{ table }}"
+        template_overwrite => true
         ssl_certificate_verification => false
     }
 }

--- a/log-collection/ansible/roles/logstash/templates/templates.json
+++ b/log-collection/ansible/roles/logstash/templates/templates.json
@@ -1,0 +1,56 @@
+{
+  "index_patterns": [
+    "{{ table }}"
+  ],
+  "settings": {},
+  "mappings": {
+    "_default_": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "@version": {
+          "type": "keyword"
+        },
+        "call-id": {
+          "type": "keyword"
+        },
+        "term_callid": {
+          "type": "keyword"
+        },
+        "by_callid": {
+          "type": "keyword"
+        },
+        "time_start": {
+          "type": "text"
+        },
+        "time_release": {
+          "type": "text"
+        },
+        "sas_time_start": {
+          "type": "text"
+        },
+        "duration": {
+          "type": "double"
+        },
+        "orig_from_user": {
+          "type": "text"
+        },
+        "orig_to_user": {
+          "type": "text"
+        },
+        "orig_ip": {
+          "type": "text"
+        },
+        "term_ip": {
+          "type": "text"
+        },
+        "release_text": {
+          "type": "text"
+        }
+      },
+      "dynamic_templates": [],
+      "numeric_detection": false
+    }
+  }
+}


### PR DESCRIPTION
We're using RapidResponse `payload` to read `time_start/time_release` values, this PR added template support so we can have correct values in RapidResponse `fields`

Notes:
1. This PR will only add fields needed [here](https://github.com/dashbase/dashbase/blob/2b253ee8fda6632a1f13564f07835b7b3e13e12b/dashbase-web/src/main/java/io/dashbase/web/resources/ucaas/netsapiens/entities/NsCdr.java#L15-L27). 
2. Other fields will be re-indexed according to this [mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-field-mapping.html) because they were using the Filebeat template.

Verified via Logstash file input plugin(from files directly).