### PR TITLE
fix incorrect @timestamp for SAS CDRs logstash configuration

### DIFF
--- a/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
@@ -18,16 +18,18 @@ input {
 }
 
 filter {
-  date {
-    match => ["time_start", "ISO8601", "yyyy-MM-dd HH:mm:ss"]
+  mutate {
+    copy => {
+      "time_start" => "@timestamp"
+    }
+    add_field => {
+      "type" => "cdr"
+    }
   }
   mutate {
     rename => {
       "orig_callid" => "call-id"
       "time_start" => "sas_time_start"
-    }
-    add_field => {
-      "type" => "cdr"
     }
   }
 }


### PR DESCRIPTION
When JDBC driver reads datetime field from the database, the field type is NOT string, it's a date so 'date' filter conversion fails (it needs a string) and results in _dateparsefailure. We don't need to convert time_start, only copy it into @timestamp.