### PR TITLE
DB-2372 update installer script allow indexer cpu/memory can be changed

### DIFF
--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -10,8 +10,8 @@ fi
 RANDOM=$(openssl rand -hex 3 > randomstring)
 RSTRING=$(cat randomstring)
 
-DASHVERSION="2.2.7"
-AWS_EKS_SCRIPT_VERSION="2.2.7"
+DASHVERSION="2.2.11"
+AWS_EKS_SCRIPT_VERSION="2.2.11"
 AWS_ACCESS_KEY="undefined"
 AWS_SECRET_ACCESS_KEY="undefined"
 REGION="us-east-2"

--- a/aws_eks_dashbase_install.sh
+++ b/aws_eks_dashbase_install.sh
@@ -264,10 +264,17 @@ check_input() {
     log_info "Entered aws secret access key = $AWS_SECRET_ACCESS_KEY"
     log_info "Default AWS region = $REGION"
     # check dashbase version
-     if [[ "$V2_FLAG" ==  "true" ]] || [[ ${VNUM} -ge 2 ]]; then
-       log_info "dashbase V2 is selected"
+     if [[ ${VNUM} -ge 2 ]] && [[ "$INSTYPE" == "r5.xlarge" ]]; then
+       log_info "dashbase V2 is selected and no instance type provided"
        INSTYPE="c5.4xlarge"
-       if [ "$CLUSTERSIZE" == "small" ]; then NODENUM=1 ; fi
+       if [[ "$NODENUM" -lt 2 ]]; then
+         log_fatal "Entered node number must be equal or greater than two"
+       fi
+     elif [[ ${VNUM} -ge 2 ]] && [[ "$INSTYPE" != "r5.xlarge" ]]; then
+       log_info "dashbase V2 is selected and instance type is $INSTYPE"
+       if [[ "$NODENUM" -lt 2 ]]; then
+         log_fatal "Entered node number must be equal or greater than two"
+       fi
      elif [[ "$V2_FLAG" ==  "false" ]] && [[ ${VNUM} -eq 1 ]]; then
        log_info "dashbase V1 is selected"
        if [ "$CLUSTERSIZE" == "large" ]; then INSTYPE="r5.2xlarge" ; fi

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -81,11 +81,11 @@ tablesv2:
       containerConfig:
         resources:
           requests:
-            cpu: 7
-            memory: 15G
+            cpu: INXCPU
+            memory: INXMEMG
           limits:
-            cpu: 7
-            memory: 15G
+            cpu: INXCPU
+            memory: INXMEMG
 
 services:
   etcd:


### PR DESCRIPTION
Changes in this PR.

1. updated the dashbase-installer.sh script with two new flags "--indexer_cpu" and "indexer_memory", and this is for changing the indexer cpu/memory requirement.

2. updated the dashbase version to 2.2.11 on both dashbase-installer.sh script and aws_eks_dashbase_install.sh script.

3. updated the aws_eks_dashbase_install.sh script to disable small cluster setup for V2, and by default V2 setup without specify instance type, default will use c5.4xlarge, and without specifying number of nodes, and default is using two nodes.

the changes in this PR is tested using the following command line options


```
./dashbase-installer.sh --platform=aws --ingress \
                        --bucketname=s3-uhjkootysd \
                        --subdomain=raytest31.dashbase.io \
                        --basic_auth --authusername=dashadm --authpassword=admin123456 \
                        --version=2.2.11 \
                        --indexer_cpu=4 \
                        --indexer_memory=8 \
                        --tablename=mylog 
```

output of the script run is attached.

[output-dashbase-installer-script-v2.1.11.txt](https://github.com/dashbase/dashbase-installation/files/4987306/output-dashbase-installer-script-v2.1.11.txt)

And by default the installer script with v2 setup will install one V2 table (1x table manager  & 1x indexer)   and  2x searcher
![image](https://user-images.githubusercontent.com/56131833/88648469-de753700-d07b-11ea-9758-39f4088d08aa.png)

And by default etcd-operator is installed via helm before the dashbase installation.
![image](https://user-images.githubusercontent.com/56131833/88648651-111f2f80-d07c-11ea-837f-78e280dc2960.png)
 



