### PR TITLE
remove template setup from filebeat

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -49,11 +49,11 @@ processors:
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
 
-setup.template:
-  name: "{{ table }}"
-  pattern: "{{ table }}"
-  fields: "/etc/filebeat/fields.yml"
-  overwrite: false
+#setup.template:
+#  name: "{{ table }}"
+#  pattern: "{{ table }}"
+#  fields: "/etc/filebeat/fields.yml"
+#  overwrite: false
 
 #-------------------------- Elasticsearch output ------------------------------
 


### PR DESCRIPTION
We have too many different ways to setting up templates. Let's not introduce a new way.
This is subtly creating problems after onboarding.

Let's comment it out for now.