### PR TITLE
DB-2451 enable  syslog via dashbase-installer scripts 

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -22,6 +22,7 @@ CDR_FLAG="false"
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
 SYSTEM_LOG="false"
+SYSLOG_FLAG="false"
 INDEXERCPU=7
 INDEXERMEMORY=15
 
@@ -512,6 +513,12 @@ check_indexer_cpu_memory() {
   fi
 }
 
+check_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Dashbase syslog is enabled, syslog deployment set will be created for receiving syslog"
+  fi
+}
+
 preflight_check() {
   # preflight checks
   log_info "OS type running this script is $OSTYPE"
@@ -563,6 +570,7 @@ preflight_check() {
   fi
 
   check_indexer_cpu_memory
+  check_syslog
 }
 
 adminpod_setup() {
@@ -653,6 +661,7 @@ install_etcd_operator() {
   sleep 15
   ETCD_COUNT=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "kubectl get po -n dashbase |grep -c etcd-operator")
   # check etcd-operator pod counts
+  echo "Number of etcd operator pod is $ETCD_COUNT"
   if [ "$ETCD_COUNT" -eq "3" ]; then
     log_info "Dashbase etcd operator is created successfully"
   elif [ "$ETCD_COUNT" -eq "0" ]; then
@@ -733,7 +742,7 @@ update_dashbase_valuefile() {
   fi
 
   # update fluentd for syslog ingestion
-  if [ "$SYSLOG_FLAG" == "true " ]; then
+  if [ "$SYSLOG_FLAG" == "true" ]; then
      log_info "update dashbase-values.yaml file to enable fluentd for syslog ingestion"
      kubectl exec -it admindash-0 -n dashbase -- sed -i '/syslog\:/!b;n;c\ \ \ \ enabled\: true' /data/dashbase-values.yaml
   fi

--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -55,6 +55,7 @@ display_help() {
   echo "                     e.g. --indexer_cpu=4"
   echo "     --indexer_memory specify the indexer memory requirement, default memory per indexer is 15"
   echo "                     e.g. --indexer_memory=8"
+  echo "     --syslog       enable dashbase syslog daemon, e.g. --syslog"
   echo "     --valuefile    specify a custom values yaml file"
   echo "                    e.g. --valuefile=/tmp/mydashbase_values.yaml"
   echo "     --presto       enable presto component e.g. --presto"
@@ -214,6 +215,9 @@ while [[ $# -gt 0 ]]; do
     ;;
   --webrtc)
     WEBRTC_FLAG="true"
+    ;;
+  --syslog)
+    SYSLOG_FLAG="true"
     ;;
   *)
     log_fatal "Unknown parameter ($PARAM) with ${VALUE:-no value}"
@@ -726,6 +730,12 @@ update_dashbase_valuefile() {
     kubectl exec -it admindash-0 -n dashbase -- sed -i "s|INXCPU|$INDEXERCPU|g" /data/dashbase-values.yaml
     log_info "update dashbase indexer memory value to $INDEXERMEMORY"
     kubectl exec -it admindash-0 -n dashbase -- sed -i "s|INXMEM|$INDEXERMEMORY|g" /data/dashbase-values.yaml
+  fi
+
+  # update fluentd for syslog ingestion
+  if [ "$SYSLOG_FLAG" == "true " ]; then
+     log_info "update dashbase-values.yaml file to enable fluentd for syslog ingestion"
+     kubectl exec -it admindash-0 -n dashbase -- sed -i '/syslog\:/!b;n;c\ \ \ \ enabled\: true' /data/dashbase-values.yaml
   fi
 
   # update dashbase system logs

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -94,6 +94,20 @@ services:
     enabled: true
     environment:
       ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:2.3.0-rc10
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -96,7 +96,7 @@ services:
       ENABLE_K8S_DISCOVERY: "true"
   syslog:
     enabled: false
-    image: dashbase/fluentd:2.3.0-rc10
+    image: dashbase/fluentd:nightly
     kind: Deployment
     componentName: fluentd
     ports:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
@@ -75,7 +75,7 @@ services:
       ENABLE_K8S_DISCOVERY: "true"
   syslog:
     enabled: false
-    image: dashbase/fluentd:2.3.0-rc10
+    image: dashbase/fluentd:nightly
     kind: Deployment
     componentName: fluentd
     ports:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
@@ -73,6 +73,20 @@ services:
     enabled: true
     environment:
       ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:2.3.0-rc10
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
@@ -71,7 +71,7 @@ services:
       ENABLE_K8S_DISCOVERY: "true"
   syslog:
     enabled: false
-    image: dashbase/fluentd:2.3.0-rc10
+    image: dashbase/fluentd:nightly
     kind: Deployment
     componentName: fluentd
     ports:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
@@ -38,24 +38,51 @@ ingress:
   certmanager: false
   host: test.dashbase.io
 
-#tables:
-#  LOGS:
-#      replicas: 1
+etcd_cluster:
+  enabled: true
+  replicas: 3
+
+filebeat:
+  enabled: false
+  elasticsearch_url: https://table-system:7888
+
+# V1_tables
 
 tablesv2:
   LOGS:
     table_manager:
       replicas: 1
     indexer:
-      enabled: true
+      containerConfig:
+        resources:
+          requests:
+            cpu: INXCPU
+            memory: INXMEMG
+          limits:
+            cpu: INXCPU
+            memory: INXMEMG
 
 services:
   etcd:
-    enabled: true
+    enabled: false
   api:
     enabled: true
     environment:
       ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:2.3.0-rc10
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values.yaml
@@ -57,7 +57,7 @@ services:
       ENABLE_K8S_DISCOVERY: "true"
   syslog:
     enabled: false
-    image: dashbase/fluentd:2.3.0-rc10
+    image: dashbase/fluentd:nightly
     kind: Deployment
     componentName: fluentd
     ports:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values.yaml
@@ -29,9 +29,18 @@ ingress:
   certmanager: false
   host: test.dashbase.io
 
+etcd_cluster:
+  enabled: true
+  replicas: 3
+
+filebeat:
+  enabled: false
+  elasticsearch_url: https://table-system:7888
+
 tables:
   LOGS:
       replicas: 1
+# Dashbase_Logs
 
 presto:
   enabled: false
@@ -41,9 +50,25 @@ presto:
 
 services:
   etcd:
-    enabled: true
+    enabled: false
   api:
     enabled: true
+    environment:
+      ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:2.3.0-rc10
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
@@ -81,11 +81,11 @@ tablesv2:
       containerConfig:
         resources:
           requests:
-            cpu: 4
-            memory: 15G
+            cpu: INXCPU
+            memory: INXMEMG
           limits:
-            cpu: 4
-            memory: 15G
+            cpu: INXCPU
+            memory: INXMEMG
 
 services:
   etcd:
@@ -94,6 +94,20 @@ services:
     enabled: true
     environment:
       ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:2.3.0-rc10
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
@@ -96,7 +96,7 @@ services:
       ENABLE_K8S_DISCOVERY: "true"
   syslog:
     enabled: false
-    image: dashbase/fluentd:2.3.0-rc10
+    image: dashbase/fluentd:nightly
     kind: Deployment
     componentName: fluentd
     ports:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
@@ -72,6 +72,20 @@ services:
     enabled: true
     environment:
       ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:2.3.0-rc10
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
@@ -74,7 +74,7 @@ services:
       ENABLE_K8S_DISCOVERY: "true"
   syslog:
     enabled: false
-    image: dashbase/fluentd:2.3.0-rc10
+    image: dashbase/fluentd:nightly
     kind: Deployment
     componentName: fluentd
     ports:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
@@ -48,9 +48,15 @@ ingress:
   certmanager: false
   host: test.dashbase.io
 
-#tables:
-#  LOGS:
-#      replicas: 1
+etcd_cluster:
+  enabled: true
+  replicas: 3
+
+filebeat:
+  enabled: false
+  elasticsearch_url: https://table-system:7888
+
+# V1_tables
 
 tablesv2:
   LOGS:
@@ -68,19 +74,33 @@ tablesv2:
       containerConfig:
         resources:
           requests:
-            cpu: 1
-            memory: 2G
+            cpu: INXCPU
+            memory: INXMEMG
           limits:
-            cpu: 1
-            memory: 2G
+            cpu: INXCPU
+            memory: INXMEMG
 
 services:
   etcd:
-    enabled: true
+    enabled: false
   api:
     enabled: true
     environment:
       ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:nightly
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true
@@ -120,9 +140,9 @@ services:
 
   prometheus:
     enabled: true
-   # image: "dashbase/prometheus:nightly"
+  # image: "dashbase/prometheus:nightly"
     imagePullPolicy: Always
-   # prometheus_env_variable
+  # prometheus_env_variable
 
   grafana:
     enabled: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values.yaml
@@ -39,9 +39,18 @@ ingress:
   certmanager: false
   host: test.dashbase.io
 
+etcd_cluster:
+  enabled: true
+  replicas: 3
+
+filebeat:
+  enabled: false
+  elasticsearch_url: https://table-system:7888
+
 tables:
   LOGS:
       replicas: 1
+# Dashbase_Logs
 
 presto:
   enabled: false
@@ -58,9 +67,25 @@ presto:
 
 services:
   etcd:
-    enabled: true
+    enabled: false
   api:
     enabled: true
+    environment:
+      ENABLE_K8S_DISCOVERY: "true"
+  syslog:
+    enabled: false
+    image: dashbase/fluentd:nightly
+    kind: Deployment
+    componentName: fluentd
+    ports:
+      syslog: 5040
+      admin: 23241
+    expose: false
+    annotations:
+      dashbase.io/scrape: "true"
+      dashbase.io/scrape_port: "24231"
+      dashbase.io/filebeat.parser.type: "simple"
+      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
   web:
     expose: true
     enabled: true
@@ -100,9 +125,9 @@ services:
 
   prometheus:
     enabled: true
-   # image: "dashbase/prometheus:nightly"
+  # image: "dashbase/prometheus:nightly"
     imagePullPolicy: Always
-   # prometheus_env_variable
+  # prometheus_env_variable
 
   grafana:
     enabled: true

--- a/deployment-tools/dashbase-installer-localsetup.sh
+++ b/deployment-tools/dashbase-installer-localsetup.sh
@@ -22,6 +22,7 @@ CDR_FLAG="false"
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
 SYSTEM_LOG="false"
+SYSLOG_FLAG="false"
 INDEXERCPU=4
 INDEXERMEMORY=8
 
@@ -374,7 +375,14 @@ check_version() {
       log_fatal "Entered dashbase version $VERSION is invalid"
     fi
   fi
-  VNUM=$(echo $VERSION |cut -d "." -f1)
+  # set VNUM
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "nightly version is used, VNUM is set to 2 by default"
+     VNUM="2"
+  else
+     VNUM=$(echo $VERSION |cut -d "." -f1)
+     log_info "version is $VERSION and VNUM is $VNUM"
+  fi
 }
 
 check_ostype() {
@@ -463,6 +471,12 @@ check_indexer_cpu_memory() {
   fi
 }
 
+check_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Dashbase syslog is enabled, syslog deployment set will be created for receiving syslog"
+  fi
+}
+
 preflight_check() {
   # preflight checks
   log_info "OS type running this script is $OSTYPE"
@@ -478,6 +492,7 @@ preflight_check() {
     log_fatal "Failed to connect your Kubernetes API server, please check your config or network."
   fi
 
+  check_syslog
   check_k8s_permission
 
   echo ""
@@ -498,6 +513,8 @@ preflight_check() {
   else
     log_warning "This cluster doesn't have enough resources for dashbase installation(2 nodes with each have 4 core and 32 Gi at least)."
   fi
+
+  check_indexer_cpu_memory
 }
 
 adminpod_setup() {
@@ -586,11 +603,12 @@ install_etcd_operator() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase-etcd stable/etcd-operator --namespace dashbase"
   sleep 15
-  ETCD_COUNT=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "kubectl get po -n dashbase |grep -c etcd-operator")
+  ETCD_COUNT=$(kubectl exec -it admindash-0 -n dashbase -- kubectl get po -n dashbase |grep -c etcd-operator | tr -d '\r')
   # check etcd-operator pod counts
-  if [ "$ETCD_COUNT" -eq "3" ]; then
+  echo "Number of etcd operator pod is $ETCD_COUNT"
+  if [[ ${ETCD_COUNT} -eq 3 ]]; then
     log_info "Dashbase etcd operator is created successfully"
-  elif [ "$ETCD_COUNT" -eq "0" ]; then
+  elif [[ ${ETCD_COUNT} -eq 0 ]]; then
     log_fatal "Dashbase etcd operator failed to create"
   else
     log_warning "Dashbase etcd operator is still creating"
@@ -668,7 +686,7 @@ update_dashbase_valuefile() {
   fi
 
   # update fluentd for syslog ingestion
-  if [ "$SYSLOG_FLAG" == "true " ]; then
+  if [ "$SYSLOG_FLAG" == "true" ]; then
      log_info "update dashbase-values.yaml file to enable fluentd for syslog ingestion"
      kubectl exec -it admindash-0 -n dashbase -- sed -i '/syslog\:/!b;n;c\ \ \ \ enabled\: true' /data/dashbase-values.yaml
   fi
@@ -736,6 +754,12 @@ update_dashbase_valuefile() {
   # update keystore passwords for both dashbase and presto
   log_info "update dashbase and presto keystore password in dashbase-values.yaml"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "cd /data ; /data/configure_presto.sh"
+
+  # update prometheus image version
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "dashbase nightly version is used, update prometheus image to use nightly version"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i '/\# image\: \"dashbase\/prometheus\:nightly\"/a\ \ \ \ image\: dashbase\/prometheus\:nightly' /data/dashbase-values.yaml
+  fi
 
   # update dashbase license information
   if [[ "$USERNAME" == "undefined" && "$LICENSE" == "undefined" ]]; then
@@ -807,7 +831,13 @@ install_dashbase() {
   log_info "the filename for dashbase value yaml file is $DASHVALUEFILE"
   log_info "Dashbase version $VERSION  and chart version $VERSION is going to install on the target K8s cluster"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
-  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug --no-hooks > /dev/null"
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "kubectl exec -it admindash-0 -n dashbase -- helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --devel --debug"
+    kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --devel --debug > /dev/null"
+  else
+    log_info "kubectl exec -it admindash-0 -n dashbase -- bash -c helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug"
+     kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug > /dev/null"
+  fi
   echo ""
   echo "please wait a few minutes for all dashbase resources be ready"
   echo ""
@@ -844,6 +874,7 @@ expose_endpoints() {
     kubectl exec -it admindash-0 -n dashbase -- bash -c "kubectl apply -f /data/admindash-server-ingress.yaml -n dashbase"
   else
     log_info "setup LoadBalancer with https endpoints to expose services"
+    #EXPOSE_ADMIN_SERVER_FLAG="--expose-admin-server"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "/data/create-lb.sh --https $EXPOSEMON"
   fi
 }
@@ -872,6 +903,7 @@ check_basic_auth
 check_version
 check_license
 check_v2
+check_systemlog
 preflight_check
 
 # install admin pod

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -22,6 +22,7 @@ CDR_FLAG="false"
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
 SYSTEM_LOG="false"
+SYSLOG_FLAG="false"
 INDEXERCPU=4
 INDEXERMEMORY=8
 
@@ -423,7 +424,14 @@ check_version() {
       log_fatal "Entered dashbase version $VERSION is invalid"
     fi
   fi
-  VNUM=$(echo $VERSION |cut -d "." -f1)
+  # set VNUM
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "nightly version is used, VNUM is set to 2 by default"
+     VNUM="2"
+  else
+     VNUM=$(echo $VERSION |cut -d "." -f1)
+     log_info "version is $VERSION and VNUM is $VNUM"
+  fi
 }
 
 check_ostype() {
@@ -512,6 +520,12 @@ check_indexer_cpu_memory() {
   fi
 }
 
+check_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Dashbase syslog is enabled, syslog deployment set will be created for receiving syslog"
+  fi
+}
+
 preflight_check() {
   # preflight checks
   log_info "OS type running this script is $OSTYPE"
@@ -527,6 +541,7 @@ preflight_check() {
     log_fatal "Failed to connect your Kubernetes API server, please check your config or network."
   fi
 
+  check_syslog
   check_k8s_permission
 
   echo ""
@@ -651,11 +666,12 @@ install_etcd_operator() {
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase-etcd stable/etcd-operator --namespace dashbase"
   sleep 15
-  ETCD_COUNT=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "kubectl get po -n dashbase |grep -c etcd-operator")
+  ETCD_COUNT=$(kubectl exec -it admindash-0 -n dashbase -- kubectl get po -n dashbase |grep -c etcd-operator | tr -d '\r')
   # check etcd-operator pod counts
-  if [ "$ETCD_COUNT" -eq "3" ]; then
+  echo "Number of etcd operator pod is $ETCD_COUNT"
+  if [[ ${ETCD_COUNT} -eq 3 ]]; then
     log_info "Dashbase etcd operator is created successfully"
-  elif [ "$ETCD_COUNT" -eq "0" ]; then
+  elif [[ ${ETCD_COUNT} -eq 0 ]]; then
     log_fatal "Dashbase etcd operator failed to create"
   else
     log_warning "Dashbase etcd operator is still creating"
@@ -733,7 +749,7 @@ update_dashbase_valuefile() {
   fi
 
   # update fluentd for syslog ingestion
-  if [ "$SYSLOG_FLAG" == "true " ]; then
+  if [ "$SYSLOG_FLAG" == "true" ]; then
      log_info "update dashbase-values.yaml file to enable fluentd for syslog ingestion"
      kubectl exec -it admindash-0 -n dashbase -- sed -i '/syslog\:/!b;n;c\ \ \ \ enabled\: true' /data/dashbase-values.yaml
   fi
@@ -801,6 +817,12 @@ update_dashbase_valuefile() {
   # update keystore passwords for both dashbase and presto
   log_info "update dashbase and presto keystore password in dashbase-values.yaml"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "cd /data ; /data/configure_presto.sh"
+
+  # update prometheus image version
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "dashbase nightly version is used, update prometheus image to use nightly version"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i '/\# image\: \"dashbase\/prometheus\:nightly\"/a\ \ \ \ image\: dashbase\/prometheus\:nightly' /data/dashbase-values.yaml
+  fi
 
   # update dashbase license information
   if [[ "$USERNAME" == "undefined" && "$LICENSE" == "undefined" ]]; then
@@ -872,7 +894,13 @@ install_dashbase() {
   log_info "the filename for dashbase value yaml file is $DASHVALUEFILE"
   log_info "Dashbase version $VERSION  and chart version $VERSION is going to install on the target K8s cluster"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
-  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug > /dev/null"
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "kubectl exec -it admindash-0 -n dashbase -- helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --devel --debug"
+    kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --devel --debug > /dev/null"
+  else
+    log_info "kubectl exec -it admindash-0 -n dashbase -- bash -c helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug"
+     kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug > /dev/null"
+  fi
   echo ""
   echo "please wait a few minutes for all dashbase resources be ready"
   echo ""

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-DASHVERSION="2.2.7"
-INSTALLER_VERSION="2.2.7"
+DASHVERSION="2.2.11"
+INSTALLER_VERSION="2.2.11"
 PLATFORM="undefined"
 INGRESS_FLAG="false"
 V2_FLAG="false"
@@ -22,6 +22,8 @@ CDR_FLAG="false"
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
 SYSTEM_LOG="false"
+INDEXERCPU=4
+INDEXERMEMORY=8
 
 echo "Installer script version is $INSTALLER_VERSION poc setup"
 
@@ -49,6 +51,11 @@ display_help() {
   echo "     --adminpassword specify admin password to access to admin page web portal"
   echo "                     default admin passowrd is dashbase123"
   echo "                     e.g. --adminpassword=myadminpass"
+  echo "     --indexer_cpu   specify each indexer cpu requirement, default cpu per indexer is 7"
+  echo "                     e.g. --indexer_cpu=4"
+  echo "     --indexer_memory specify the indexer memory requirement, default memory per indexer is 15"
+  echo "                     e.g. --indexer_memory=8"
+  echo "     --syslog       enable dashbase syslog daemon, e.g. --syslog"
   echo "     --valuefile    specify a custom values yaml file"
   echo "                    e.g. --valuefile=/tmp/mydashbase_values.yaml"
   echo "     --presto       enable presto component e.g. --presto"
@@ -169,6 +176,14 @@ while [[ $# -gt 0 ]]; do
     fail_if_empty "$PARAM" "$VALUE"
     ADMINPASSWORD=$VALUE
     ;;
+  --indexer_cpu)
+    fail_if_empty "$PARAM" "$VALUE"
+    INDEXERCPU=$VALUE
+    ;;
+  --indexer_memory)
+    fail_if_empty "$PARAM" "$VALUE"
+    INDEXERMEMORY=$VALUE
+    ;;
   --storage_account)
     fail_if_empty "$PARAM" "$VALUE"
     STORAGE_ACCOUNT=$VALUE
@@ -200,6 +215,9 @@ while [[ $# -gt 0 ]]; do
     ;;
   --webrtc)
     WEBRTC_FLAG="true"
+    ;;
+  --syslog)
+    SYSLOG_FLAG="true"
     ;;
   *)
     log_fatal "Unknown parameter ($PARAM) with ${VALUE:-no value}"
@@ -480,6 +498,20 @@ check_v2() {
   fi
 }
 
+check_indexer_cpu_memory() {
+  # check entered indexer cpu and memory value is integer or not
+  if [[ $INDEXERCPU ]] && [ $INDEXERCPU -eq $INDEXERCPU ] && [ $INDEXERCPU -gt 0 ]; then
+    log_info "Entered indexer cpu value $INDEXERCPU and is an integer"
+  else
+    log_fatal "Entered indexer cpu value $INDEXERCPU and is not an integer"
+  fi
+   if [[ $INDEXERMEMORY ]] && [ $INDEXERMEMORY -eq $INDEXERMEMORY ] && [ $INDEXERCPU -gt 0 ]; then
+    log_info "Entered indexer memory value $INDEXERMEMORY and is an integer"
+  else
+    log_fatal "Entered indexer memory value $INDEXERMEMORY and is not an integer"
+  fi
+}
+
 preflight_check() {
   # preflight checks
   log_info "OS type running this script is $OSTYPE"
@@ -512,7 +544,7 @@ preflight_check() {
     if [ $AVAIILABLE_NODES -ge 1 ]; then
       log_info "This cluster is ready for dashbase installation on resources"
     else
-      log_fatal "This cluster doesn't have enough resources for dashbase installation(1 node with minium 16 cores and 32 Gi memory)."
+      log_warning "This cluster doesn't have enough resources for dashbase installation(1 node with minium 16 cores and 32 Gi memory)."
     fi
   else
     AVAIILABLE_NODES=0
@@ -526,9 +558,11 @@ preflight_check() {
     if [ $AVAIILABLE_NODES -ge 2 ]; then
       log_info "This cluster is ready for dashbase installation on resources"
     else
-      log_fatal "This cluster doesn't have enough resources for dashbase installation(2 nodes with each have 4 cores and 32 Gi memory at least)."
+      log_warning "This cluster doesn't have enough resources for dashbase installation(2 nodes with each have 4 cores and 32 Gi memory at least)."
     fi
   fi
+
+  check_indexer_cpu_memory
 }
 
 adminpod_setup() {
@@ -689,6 +723,20 @@ update_dashbase_valuefile() {
   log_info "update dashbase-values.yaml file with table name = $TABLENAME"
   kubectl exec -it admindash-0 -n dashbase -- sed -i "s|LOGS|$TABLENAME|" /data/dashbase-values.yaml
   kubectl exec -it admindash-0 -n dashbase -- sed -i "s|LOGS|$TABLENAME|" /data/exporter_metric.yaml
+
+  # update indexer cpu and memory
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
+    log_info "update dashbase indexer cpu value to $INDEXERCPU"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i "s|INXCPU|$INDEXERCPU|g" /data/dashbase-values.yaml
+    log_info "update dashbase indexer memory value to $INDEXERMEMORY"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i "s|INXMEM|$INDEXERMEMORY|g" /data/dashbase-values.yaml
+  fi
+
+  # update fluentd for syslog ingestion
+  if [ "$SYSLOG_FLAG" == "true " ]; then
+     log_info "update dashbase-values.yaml file to enable fluentd for syslog ingestion"
+     kubectl exec -it admindash-0 -n dashbase -- sed -i '/syslog\:/!b;n;c\ \ \ \ enabled\: true' /data/dashbase-values.yaml
+  fi
 
   # update dashbase system logs
   if [ "$SYSTEM_LOG" == "true" ]; then

--- a/deployment-tools/dashbase-installer-tinysetup.sh
+++ b/deployment-tools/dashbase-installer-tinysetup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-DASHVERSION="2.2.7"
-INSTALLER_VERSION="2.2.7"
+DASHVERSION="2.2.11"
+INSTALLER_VERSION="2.2.11"
 PLATFORM="undefined"
 INGRESS_FLAG="false"
 V2_FLAG="false"
@@ -21,6 +21,10 @@ TABLENAME="logs"
 CDR_FLAG="false"
 DEMO_FLAG="false"
 WEBRTC_FLAG="false"
+SYSTEM_LOG="false"
+SYSLOG_FLAG="false"
+INDEXERCPU=2
+INDEXERMEMORY=3
 
 echo "Installer script version is $INSTALLER_VERSION local setup for install testing only"
 
@@ -48,6 +52,11 @@ display_help() {
   echo "     --adminpassword specify admin password to access to admin page web portal"
   echo "                     default admin passowrd is dashbase123"
   echo "                     e.g. --adminpassword=myadminpass"
+  echo "     --indexer_cpu   specify each indexer cpu requirement, default cpu per indexer is 7"
+  echo "                     e.g. --indexer_cpu=4"
+  echo "     --indexer_memory specify the indexer memory requirement, default memory per indexer is 15"
+  echo "                     e.g. --indexer_memory=8"
+  echo "     --syslog       enable dashbase syslog daemon, e.g. --syslog"
   echo "     --valuefile    specify a custom values yaml file"
   echo "                    e.g. --valuefile=/tmp/mydashbase_values.yaml"
   echo "     --presto       enable presto component e.g. --presto"
@@ -57,6 +66,8 @@ display_help() {
   echo "     --cdr          enable cdr log data for insight page  e.g. --cdr"
   echo "     --help         display command options and usage example"
   echo "     --webrtc       enable remote read on prometheus to api url for webrtc data e.g. --webrtc"
+  echo "     --systemlog    enable dashbase system log table, e.g. --systemlog  this will create a table called system."
+  echo "                    and contains all dashbase pods logs in this system table"
   echo "     --demo         setup freeswitch,filebeat pods and feed log data into the target table"
   echo ""
   echo "   The following options only be used on V2 dashbase"
@@ -166,6 +177,14 @@ while [[ $# -gt 0 ]]; do
     fail_if_empty "$PARAM" "$VALUE"
     ADMINPASSWORD=$VALUE
     ;;
+  --indexer_cpu)
+    fail_if_empty "$PARAM" "$VALUE"
+    INDEXERCPU=$VALUE
+    ;;
+  --indexer_memory)
+    fail_if_empty "$PARAM" "$VALUE"
+    INDEXERMEMORY=$VALUE
+    ;;
   --storage_account)
     fail_if_empty "$PARAM" "$VALUE"
     STORAGE_ACCOUNT=$VALUE
@@ -192,8 +211,14 @@ while [[ $# -gt 0 ]]; do
   --demo)
     DEMO_FLAG="true"
     ;;
+  --systemlog)
+    SYSTEM_LOG="true"
+    ;;
   --webrtc)
     WEBRTC_FLAG="true"
+    ;;
+  --syslog)
+    SYSLOG_FLAG="true"
     ;;
   *)
     log_fatal "Unknown parameter ($PARAM) with ${VALUE:-no value}"
@@ -350,7 +375,14 @@ check_version() {
       log_fatal "Entered dashbase version $VERSION is invalid"
     fi
   fi
-  VNUM=$(echo $VERSION |cut -d "." -f1)
+  # set VNUM
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "nightly version is used, VNUM is set to 2 by default"
+     VNUM="2"
+  else
+     VNUM=$(echo $VERSION |cut -d "." -f1)
+     log_info "version is $VERSION and VNUM is $VNUM"
+  fi
 }
 
 check_ostype() {
@@ -366,6 +398,14 @@ check_ostype() {
     fi
   else
     log_warning "Dedected current workstation OS is neither mac, centos, ubuntu"
+  fi
+}
+
+check_systemlog() {
+  if [ "$SYSTEM_LOG" == "false" ]; then
+    log_info "Dashbase system logs is not collected and displayed in the dashbase web portal"
+  else
+    log_info "Dashbase system logs is enabled, a table named system will use to display dashbase pods logs"
   fi
 }
 
@@ -403,6 +443,7 @@ check_v2() {
        log_fatal "V2 is selected but not provide any cloud object storage bucket name"
     elif [ "$BUCKETNAME" != "undefined" ]; then
        log_info "V2 is selected and bucket name is $BUCKETNAME"
+       V2_NODE="true"
     fi
     if [ "$PLATFORM" == "gce" ] || [ "$PLATFORM" == "azure" ]; then
        log_info "V2 is selected and cloud platform is $PLATFORM"
@@ -412,6 +453,27 @@ check_v2() {
     fi
   elif [[ "$V2_FLAG" ==  "false" ]] && [[ ${VNUM} -eq 1 ]]; then
       log_info "V2 is not selected in this installation"
+      V2_NODE="false"
+  fi
+}
+
+check_indexer_cpu_memory() {
+  # check entered indexer cpu and memory value is integer or not
+  if [[ $INDEXERCPU ]] && [ $INDEXERCPU -eq $INDEXERCPU ] && [ $INDEXERCPU -gt 0 ]; then
+    log_info "Entered indexer cpu value $INDEXERCPU and is an integer"
+  else
+    log_fatal "Entered indexer cpu value $INDEXERCPU and is not an integer"
+  fi
+   if [[ $INDEXERMEMORY ]] && [ $INDEXERMEMORY -eq $INDEXERMEMORY ] && [ $INDEXERCPU -gt 0 ]; then
+    log_info "Entered indexer memory value $INDEXERMEMORY and is an integer"
+  else
+    log_fatal "Entered indexer memory value $INDEXERMEMORY and is not an integer"
+  fi
+}
+
+check_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Dashbase syslog is enabled, syslog deployment set will be created for receiving syslog"
   fi
 }
 
@@ -430,6 +492,7 @@ preflight_check() {
     log_fatal "Failed to connect your Kubernetes API server, please check your config or network."
   fi
 
+  check_syslog
   check_k8s_permission
 
   echo ""
@@ -446,7 +509,7 @@ preflight_check() {
   if [ $AVAIILABLE_NODES -ge 3 ]; then
     log_info "This cluster is ready for dashbase installation on resources"
   else
-    log_fatal "This cluster doesn't have enough resources for dashbase installation(3 nodes with each have 2 core and 4 Gi at least)."
+    log_warning "This cluster doesn't have enough resources for dashbase installation(3 nodes with each have 2 core and 4 Gi at least)."
   fi
 }
 
@@ -530,6 +593,24 @@ create_storageclass() {
   if [ "$STORECLASSCHK" -eq "3" ]; then echo "Dashbase storageclasses are available"; else log_fatal "Dashbase storageclasses not found"; fi
 }
 
+install_etcd_operator() {
+  # setup etcd-operator
+  log_info "Setup etcd operator via helm"
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
+  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase-etcd stable/etcd-operator --namespace dashbase"
+  sleep 15
+  ETCD_COUNT=$(kubectl exec -it admindash-0 -n dashbase -- kubectl get po -n dashbase |grep -c etcd-operator | tr -d '\r')
+  # check etcd-operator pod counts
+  echo "Number of etcd operator pod is $ETCD_COUNT"
+  if [[ ${ETCD_COUNT} -eq 3 ]]; then
+    log_info "Dashbase etcd operator is created successfully"
+  elif [[ ${ETCD_COUNT} -eq 0 ]]; then
+    log_fatal "Dashbase etcd operator failed to create"
+  else
+    log_warning "Dashbase etcd operator is still creating"
+  fi
+}
+
 download_dashbase() {
   # download and update the dashbase helm value yaml files
   log_info "Downloading dashbase setup tar file from Github"
@@ -592,6 +673,31 @@ update_dashbase_valuefile() {
   kubectl exec -it admindash-0 -n dashbase -- sed -i "s|LOGS|$TABLENAME|" /data/dashbase-values.yaml
   kubectl exec -it admindash-0 -n dashbase -- sed -i "s|LOGS|$TABLENAME|" /data/exporter_metric.yaml
 
+  # update indexer cpu and memory
+  if [[ "$V2_FLAG" ==  "true" ]] || [[ "$VNUM" -ge 2 ]]; then
+    log_info "update dashbase indexer cpu value to $INDEXERCPU"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i "s|INXCPU|$INDEXERCPU|g" /data/dashbase-values.yaml
+    log_info "update dashbase indexer memory value to $INDEXERMEMORY"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i "s|INXMEM|$INDEXERMEMORY|g" /data/dashbase-values.yaml
+  fi
+
+  # update fluentd for syslog ingestion
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+     log_info "update dashbase-values.yaml file to enable fluentd for syslog ingestion"
+     kubectl exec -it admindash-0 -n dashbase -- sed -i '/syslog\:/!b;n;c\ \ \ \ enabled\: true' /data/dashbase-values.yaml
+  fi
+
+  # update dashbase system logs
+  if [ "$SYSTEM_LOG" == "true" ]; then
+    log_info "update dashbase-values.yaml file to enable dashbase system log collection"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i '/filebeat\:/!b;n;c\ \ enabled\: true' /data/dashbase-values.yaml
+    if [ "$VNUM" -ge 2 ]; then
+       kubectl exec -it admindash-0 -n dashbase -- sed -i '/V1_tables/ r /data/dashbase_system_log_table_v2_poc.yaml' /data/dashbase-values.yaml
+    else
+       kubectl exec -it admindash-0 -n dashbase -- sed -i '/Dashbase_Logs/ r /data/dashbase_system_log_table_v1_poc.yaml' /data/dashbase-values.yaml
+    fi
+  fi
+
   # update ucaas feature
   if [ "$UCAAS_FLAG" == "true" ]; then
     log_info "update dashbase-values.yaml file to enable UCAAS features"
@@ -644,6 +750,12 @@ update_dashbase_valuefile() {
   # update keystore passwords for both dashbase and presto
   log_info "update dashbase and presto keystore password in dashbase-values.yaml"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "cd /data ; /data/configure_presto.sh"
+
+  # update prometheus image version
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "dashbase nightly version is used, update prometheus image to use nightly version"
+    kubectl exec -it admindash-0 -n dashbase -- sed -i '/\# image\: \"dashbase\/prometheus\:nightly\"/a\ \ \ \ image\: dashbase\/prometheus\:nightly' /data/dashbase-values.yaml
+  fi
 
   # update dashbase license information
   if [[ "$USERNAME" == "undefined" && "$LICENSE" == "undefined" ]]; then
@@ -715,7 +827,13 @@ install_dashbase() {
   log_info "the filename for dashbase value yaml file is $DASHVALUEFILE"
   log_info "Dashbase version $VERSION  and chart version $VERSION is going to install on the target K8s cluster"
   kubectl exec -it admindash-0 -n dashbase -- bash -c "helm repo update"
-  kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug > /dev/null"
+  if [[ "$VERSION" == *"nightly"* ]]; then
+    log_info "kubectl exec -it admindash-0 -n dashbase -- helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --devel --debug"
+    kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --devel --debug > /dev/null"
+  else
+    log_info "kubectl exec -it admindash-0 -n dashbase -- bash -c helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug"
+     kubectl exec -it admindash-0 -n dashbase -- bash -c "helm install dashbase dashbase/dashbase -f /data/$DASHVALUEFILE --namespace dashbase --version $VERSION --debug > /dev/null"
+  fi
   echo ""
   echo "please wait a few minutes for all dashbase resources be ready"
   echo ""
@@ -781,6 +899,7 @@ check_basic_auth
 check_version
 check_license
 check_v2
+check_systemlog
 preflight_check
 
 # install admin pod
@@ -801,6 +920,7 @@ fi
 
 check_helm
 create_sslcert
+install_etcd_operator
 
 # setup dashbase value yaml file and install dashbase
 if [ "$VALUEFILE" == "dashbase-values.yaml" ]; then

--- a/deployment-tools/setup-s3-4v2.sh
+++ b/deployment-tools/setup-s3-4v2.sh
@@ -4,7 +4,7 @@ openssl rand -hex 4 >randomstring2
 RSTRING2=$(cat randomstring2)
 
 CLUSTERNAME="dashbase-$RSTRING2"
-CMDS="curl tar unzip git aws"
+CMDS="curl tar unzip git aws kubectl"
 REGION="us-east-2"
 
 # log functions and input flag setup
@@ -64,7 +64,6 @@ check_commands() {
 
 BUCKETNAME="s3-$CLUSTERNAME"
 
-# main process below this line
 log_info "the S3 bucket that will be created with name $BUCKETNAME"
 # create s3 bucket
 create_s3() {
@@ -77,13 +76,30 @@ create_s3() {
   fi
 }
 
+check_ostype() {
+  if [[ $OSTYPE == *"darwin"* ]]; then
+    WKOSTYPE="mac"
+    log_fatal "Dedected current workstation is a $WKOSTYPE, this script only tested on linux"
+    WKOSTYPE="mac"
+  elif [[ $OSTYPE == *"linux"* ]]; then
+    log_info "Dedected current workstation is a $WKOSTYPE"
+    WKOSTYPE="linux"
+  else
+    log_fatal "This script is only tested on linux; and fail to detect the current worksattion os type"
+  fi
+}
+
 # update bucket policy json with BUCKETNAME
 update_s3_policy_json() {
    # remove any previous mydash-s3.json file if exists
    rm -rf mydash-s3.json
    # download the mydash-s3.json from github
    curl -k https://raw.githubusercontent.com/dashbase/dashbase-installation/master/deployment-tools/mydash-s3.json -o mydash-s3.json
-   sed -i "s/MYDASHBUCKET/$BUCKETNAME/" mydash-s3.json
+   if [ "$WKOSTYPE" == "mac" ]; then
+      sed -i "" "s/MYDASHBUCKET/$BUCKETNAME/" mydash-s3.json
+   elif [ "$WKOSTYPE" == "linux" ]; then
+      sed -i "s/MYDASHBUCKET/$BUCKETNAME/" mydash-s3.json
+   fi
 }
 
 # create s3 bucket policy
@@ -120,6 +136,8 @@ insert_s3_policy_to_nodegroup() {
   fi
 
 }
+
+# main process below this line
 #run_by_root
 check_commands
 create_s3

--- a/deployment-tools/setup-s3-4v2.sh
+++ b/deployment-tools/setup-s3-4v2.sh
@@ -140,6 +140,7 @@ insert_s3_policy_to_nodegroup() {
 # main process below this line
 #run_by_root
 check_commands
+check_ostype
 create_s3
 update_s3_policy_json
 create_s3_bucket_policy

--- a/deployment-tools/uninstall-dashbase.sh
+++ b/deployment-tools/uninstall-dashbase.sh
@@ -70,6 +70,17 @@ remove_demo_setup() {
   fi
 }
 
+remove_fluentd() {
+  # delete syslog pods
+  # delete demo freeswitch pods
+  if [ "$(kubectl get deployment -n dashbase |grep -c syslog)" -gt "0" ]; then
+     log_info "syslog deployment sets exists"
+     kubectl delete deployment syslog -n dashbase
+  else
+     log_info "no syslog deployment set is found"
+  fi
+}
+
 remove_tiller() {
     #  delete helm tiller
     if [ "$(kubectl get po -n kube-system |grep -c tiller-deploy)" -gt "0" ]; then
@@ -332,6 +343,8 @@ remove_sa_dashadmin() {
 remove_combo() {
     # delete demo setup
     remove_demo_setup
+    # delete syslog deployment set
+    remove_fluentd
     # delete pvc
     delete_dashbase_pvc
     # delete secrets


### PR DESCRIPTION
Changes in this PR
related to ticket DB-2451 "Add option to enable syslog service and expose tcp load balancer in installer"

1. Added a new flag "--syslog" to enable syslog service via dashbase-installer.sh script.

2. Fixed the etcd_operator check which result in minor error in echo message 
    The error `")syntax error: invalid arithmetic operator (error token is "` is caused by newline or carriage return on a numeric variable

3.  Improved all dashbase-installer scripts to support nightly version. Nightly version was error out due to version number variable  `VNUM` is introduced last time. 

4  Updated uninstall-dashbase.sh script to support removal of dashbase syslog deployment set

5. Update `setup-s3-4v2.sh`  S3 bucket creation script to run on both mac and linux

Tested dashbase-installer.sh script with following script options and result is positive. script run output is attached

```
./dashbase-installer.sh --platform=aws --ingress \
                                       --bucketname=s3-kkjiktyh01 \
                                       --subdomain=raytest33.dashbase.io \
                                       --basic_auth --authusername=dashadm --authpassword=admin123456 \
                                       --version=nightly-84c552 \
                                       --syslog
```

Additionally, the following scripts are tested and output is attached 

1. dashbase-installer-smallsetup.sh
2. dashbase-installer-tinysetup.sh
3. uninstall-dashbase.sh
4. setup-s3-4v2.sh

Currently enable syslog via installer script does not exposed the service yet. This changes will be. on next PR.
expose syslog service will be using  load balancer instead of ingress; since syslog service normally run either in tcp/udp port 5054 rather than https protocol.

[output-dashbase-installer-08022020a.txt](https://github.com/dashbase/dashbase-installation/files/5027866/output-dashbase-installer-08022020a.txt)
[output-dashbase-installer-smallsetup-08022020a.txt](https://github.com/dashbase/dashbase-installation/files/5027865/output-dashbase-installer-smallsetup-08022020a.txt)
[output-dashbase-installer-tinysetup-08022020a.txt](https://github.com/dashbase/dashbase-installation/files/5027863/output-dashbase-installer-tinysetup-08022020a.txt)
[output-uninstall-dashbase-08022020a.txt](https://github.com/dashbase/dashbase-installation/files/5027864/output-uninstall-dashbase-08022020a.txt)
[output-setup-s3-4v2-08022020a.txt](https://github.com/dashbase/dashbase-installation/files/5027876/output-setup-s3-4v2-08022020a.txt)



