### PR TITLE
DB-2451 update syslog configuration in dashbase-values.yaml

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -942,6 +942,13 @@ expose_endpoints() {
   fi
 }
 
+expose_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Expose dashbase syslog via load balancer in TCP port 5040"
+    kubectl expose service syslog --port=5040 --target-port=5040 --name=syslog-lb --type=LoadBalancer -l type=lb -n dashbase
+  fi
+}
+
 demo_setup() {
   if [ "$DEMO_FLAG" == "true" ]; then
     ES_HOSTS="https://table-$TABLENAME:7888"
@@ -1002,6 +1009,7 @@ fi
 
 # expose services
 expose_endpoints
+expose_syslog
 
 # demo setup
 demo_setup

--- a/deployment-tools/check-fed-search.sh
+++ b/deployment-tools/check-fed-search.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+function log_info() {
+  echo -e "INFO *** $*"
+}
+
+function log_warning() {
+  echo -e "WARN *** $*"
+}
+
+function log_error() {
+  echo -e "ERROR *** $*"
+}
+
+function log_fatal() {
+  echo -e "FATAL *** $*"
+  exit 1
+}
+
+CMDS="kubectl jq"
+for x in $CMDS; do
+  command -v "$x" >/dev/null && continue || {
+    log_fatal "This script requires $x command and is not found."
+  }
+done
+
+APIHOST=$(kubectl get po -n dashbase | grep api | awk '{print $1}')
+#DNSHOST=$(kubectl get po -n kube-system | grep -E 'kube-dns|coredns' | awk '{print $1}' | tr '\n' ' ')
+DNSCM=$(kubectl get cm -n kube-system |grep -E 'kube-dns|coredns' |sort |uniq |awk '{print $1}')
+#STUBDOMAIN=$(kubectl get cm $DNSCM -n kube-system -o=jsonpath='{.data.stubDomains}' | jq |grep ":" |sed -e 's/\"//g; s/\[//g; s/\://g' |awk '{$1=$1;print}' | tr '\n' ' ' |awk '{$1=$1;print}')
+DOWNAPI=$(kubectl describe po $APIHOST -n dashbase |grep DOWNSTREAM_APIS |awk '{print $2}' |sed 's/https\?:\/\///g; s/\://g; s/9876//g; s/\,/\ /')
+#INTTOKEN=changeme
+
+# main process below this line
+log_info "upstream api pod is $APIHOST"
+log_info "stud domains and its corresponding dns servers are followings"
+kubectl get cm $DNSCM -n kube-system -o=jsonpath='{.data.stubDomains}' | jq
+
+rm -rf /tmp/apipingtest
+
+for X in $DOWNAPI; do
+  log_info " ping to $X"
+  kubectl exec -it $APIHOST -n dashbase -- ping $X -i1 -c1 |grep "%" | tee -a /tmp/apipingtest
+  IPA=$(kubectl exec -it $APIHOST -n dashbase -- ping $X -i1 -c1  |grep PING |awk '{ print $3}' |sed -e 's|(||; s|)||')
+  if [ "$(kubectl exec -it $APIHOST -n dashbase -- ping $X -i1 -c1 |grep "%" |awk '{print $6}')" == "0%" ]; then
+     log_info "ping test to  $X with internal IP address $IPA ---- PASS"
+     # uncomment the following lines after update INTTOKEN env var
+     #DWNTABLE=$(kubectl exec -it $APIHOST -n dashbase -- curl -k "https://$X:9876/v1/cluster/tables" -v  -H 'Authorization: Bearer $INTTOKEN' |tail -1)
+     #log_info "From downstream api $X , the tables are $DWNTABLE"
+  else
+     log_error "ping test to $X is FAIL"
+     log_info "Please check the kube-dns configmap $DNSCM"
+     log_info "Please check the downstream api po $X with internal IP address $IPA"
+     log_info "Please check the network route and network security policy on both sides"
+  fi
+done
+

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -97,17 +97,12 @@ services:
   syslog:
     enabled: false
     image: dashbase/fluentd:nightly
-    kind: Deployment
-    componentName: fluentd
-    ports:
-      syslog: 5040
-      admin: 23241
-    expose: false
-    annotations:
-      dashbase.io/scrape: "true"
-      dashbase.io/scrape_port: "24231"
-      dashbase.io/filebeat.parser.type: "simple"
-      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
+    imagePullPolicy: Always
+    environment:
+      SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
+      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+      SYSLOG_MESSAGE_FORMAT: rfc5424
+
   web:
     expose: true
     enabled: true
@@ -149,6 +144,9 @@ services:
     enabled: true
   # image: "dashbase/prometheus:nightly"
     imagePullPolicy: Always
+    storage:
+      class: "dashbase-meta"
+      size: 20Gi
   # prometheus_env_variable
 
   grafana:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -100,8 +100,8 @@ services:
     imagePullPolicy: Always
     environment:
       SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
-      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
-      SYSLOG_MESSAGE_FORMAT: rfc5424
+#     SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+#     SYSLOG_MESSAGE_FORMAT: rfc5424
 
   web:
     expose: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
@@ -72,17 +72,12 @@ services:
   syslog:
     enabled: false
     image: dashbase/fluentd:nightly
-    kind: Deployment
-    componentName: fluentd
-    ports:
-      syslog: 5040
-      admin: 23241
-    expose: false
-    annotations:
-      dashbase.io/scrape: "true"
-      dashbase.io/scrape_port: "24231"
-      dashbase.io/filebeat.parser.type: "simple"
-      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
+    imagePullPolicy: Always
+    environment:
+      SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
+      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+      SYSLOG_MESSAGE_FORMAT: rfc5424
+
   web:
     expose: true
     enabled: true
@@ -116,6 +111,9 @@ services:
     enabled: true
    # image: "dashbase/prometheus:nightly"
     imagePullPolicy: Always
+    storage:
+      class: "dashbase-meta"
+      size: 20Gi
    # prometheus_env_variable
 
   grafana:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
@@ -75,8 +75,8 @@ services:
     imagePullPolicy: Always
     environment:
       SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
-      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
-      SYSLOG_MESSAGE_FORMAT: rfc5424
+#     SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+#     SYSLOG_MESSAGE_FORMAT: rfc5424
 
   web:
     expose: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
@@ -97,17 +97,12 @@ services:
   syslog:
     enabled: false
     image: dashbase/fluentd:nightly
-    kind: Deployment
-    componentName: fluentd
-    ports:
-      syslog: 5040
-      admin: 23241
-    expose: false
-    annotations:
-      dashbase.io/scrape: "true"
-      dashbase.io/scrape_port: "24231"
-      dashbase.io/filebeat.parser.type: "simple"
-      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
+    imagePullPolicy: Always
+    environment:
+      SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
+      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+      SYSLOG_MESSAGE_FORMAT: rfc5424
+
   web:
     expose: true
     enabled: true
@@ -149,6 +144,9 @@ services:
     enabled: true
   # image: "dashbase/prometheus:nightly"
     imagePullPolicy: Always
+    storage:
+      class: "dashbase-meta"
+      size: 20Gi
   # prometheus_env_variable
 
   grafana:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
@@ -100,8 +100,8 @@ services:
     imagePullPolicy: Always
     environment:
       SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
-      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
-      SYSLOG_MESSAGE_FORMAT: rfc5424
+#     SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+#     SYSLOG_MESSAGE_FORMAT: rfc5424
 
   web:
     expose: true

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
@@ -90,17 +90,12 @@ services:
   syslog:
     enabled: false
     image: dashbase/fluentd:nightly
-    kind: Deployment
-    componentName: fluentd
-    ports:
-      syslog: 5040
-      admin: 23241
-    expose: false
-    annotations:
-      dashbase.io/scrape: "true"
-      dashbase.io/scrape_port: "24231"
-      dashbase.io/filebeat.parser.type: "simple"
-      dashbase.io/filebeat.parser.pattern: "yyyy-MM-dd HH:mm:ss Z"
+    imagePullPolicy: Always
+    environment:
+      SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
+      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+      SYSLOG_MESSAGE_FORMAT: rfc5424
+
   web:
     expose: true
     enabled: true
@@ -142,6 +137,9 @@ services:
     enabled: true
   # image: "dashbase/prometheus:nightly"
     imagePullPolicy: Always
+    storage:
+      class: "dashbase-meta"
+      size: 20Gi
   # prometheus_env_variable
 
   grafana:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
@@ -93,8 +93,8 @@ services:
     imagePullPolicy: Always
     environment:
       SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
-      SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
-      SYSLOG_MESSAGE_FORMAT: rfc5424
+#     SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
+#     SYSLOG_MESSAGE_FORMAT: rfc5424
 
   web:
     expose: true

--- a/deployment-tools/dashbase-installer-smallsetup.sh
+++ b/deployment-tools/dashbase-installer-smallsetup.sh
@@ -942,6 +942,13 @@ expose_endpoints() {
   fi
 }
 
+expose_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Expose dashbase syslog via load balancer in TCP port 5040"
+    kubectl expose service syslog --port=5040 --target-port=5040 --name=syslog-lb --type=LoadBalancer -l type=lb -n dashbase
+  fi
+}
+
 demo_setup() {
   if [ "$DEMO_FLAG" == "true" ]; then
     ES_HOSTS="https://table-$TABLENAME:7888"
@@ -1002,6 +1009,7 @@ fi
 
 # expose services
 expose_endpoints
+expose_syslog
 
 # demo setup
 demo_setup

--- a/deployment-tools/dashbase-installer-tinysetup.sh
+++ b/deployment-tools/dashbase-installer-tinysetup.sh
@@ -875,6 +875,13 @@ expose_endpoints() {
   fi
 }
 
+expose_syslog() {
+  if [ "$SYSLOG_FLAG" == "true" ]; then
+    log_info "Expose dashbase syslog via load balancer in TCP port 5040"
+    kubectl expose service syslog --port=5040 --target-port=5040 --name=syslog-lb --type=LoadBalancer -l type=lb -n dashbase
+  fi
+}
+
 demo_setup() {
   if [ "$DEMO_FLAG" == "true" ]; then
     ES_HOSTS="https://table-$TABLENAME:7888"
@@ -935,6 +942,7 @@ fi
 
 # expose services
 expose_endpoints
+expose_syslog
 
 # demo setup
 demo_setup


### PR DESCRIPTION
Changes in this PR

1. update syslog configuration in dashbase-values.yaml file with following env variables
 
```
      SYSLOG_ELASTICSEARCH_HOSTS: https://table-LOGS:7888
#     SYSLOG_MESSAGE_PARSER: "{\"_message_parser\":{\"type\":\"grok\",\"pattern\":\"%{HTTPD_COMBINEDLOG}\"}}"
#     SYSLOG_MESSAGE_FORMAT: rfc5424
```

 `SYSLOG_MESSAGE_PARSER` and `SYSLOG_MESSAGE_FORMAT` is currently comment out  and this use case should be explained in wiki page and have customer to enable them..

Added expose_syslog function to expose syslog service using  LB 

2.  Increase the proemtheus pod stateful volume from 10Gi to 20Gi. We find some customers easily fill up prometheus disk. 

3. Added a check-fed-search.sh script, this is a troubleshooting script to easily check federated search health status and provides recommendation when error is detected. And this script should be run in primary dashbase site.

The following is sample script output.
![image](https://user-images.githubusercontent.com/56131833/90003824-7f9de900-dc49-11ea-9204-103ef6121a38.png)




