### PR TITLE
Remove overwrite true for filebeat

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -53,7 +53,7 @@ setup.template:
   name: "{{ table }}"
   pattern: "{{ table }}"
   fields: "/etc/filebeat/fields.yml"
-  overwrite: true
+  overwrite: false
 
 #-------------------------- Elasticsearch output ------------------------------
 


### PR DESCRIPTION
We shouldn't default to `overwrite: true` this could cause pressure on etcd for template uploads.
This requires a re-deploy of filebeats.