### PR TITLE
modified avaya config based on latest sample provided

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/avaya.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/avaya.yml
@@ -1,12 +1,12 @@
 - type: log
   paths:
-    - /var/log/*.txt
+    - /var/log/*sbc*
   fields:
     _message_parser:
       type: grok
-      pattern: '\"%{NOTSPACE:system:meta}\",\"%{INT:log_level:int}\",\"%{DATA:timestamp:datetime:yyyy-MMM-dd HH:mm:ss}\",\"%{DATA:event_end}\",\"%{INT:log_facility:int}\",\"%{DATA:message}\",\"%{NOTSPACE:ip_port}\"'
+      pattern: '%{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:system:meta} %{GREEDYDATA:message}'
 
-  multiline.pattern: ^\"[a-zA-Z]
+  multiline.pattern: ^\d{4}-\d{2}-\d{2}
   close_inactive: 90s
   harvester_limit: 5000
   scan_frequency: 1s


### PR DESCRIPTION
Updated pattern for the latest sample provided by Maintel after they enabled avaya SBC to send data to a rsyslog server.
Sample:
`2020-09-03T17:07:19+01:00 mntl1-vm-sbc1 SSYNDI[3357]: REGISTRATIONS INFO REG 296 SIPRELAY_REGISTRATION:Registration:  Transport Tuple = tls-86.140.3.203:63152=>10.20.24.201:5061, Is Far-end User = Yes, Is a response to Authentication Challenge = No, Subscriber Aor = sips:184549@maintel.co.uk, Number of Bindings = 1:  Binding - 1 = sips:184549@192.168.1.176:63152;expires=3600`

pattern:
`%{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:system:meta} %{GREEDYDATA:message}`