### PR TITLE
provide default filebeat inventory file to be able to run ansible loc…

### DIFF
--- a/log-collection/ansible/inventory
+++ b/log-collection/ansible/inventory
@@ -1,0 +1,2 @@
+[filebeat_hosts]
+127.0.0.1


### PR DESCRIPTION
…ally
During POCs, may customers need to install only to one host locally. It's useful to have default inventory file.