### PR TITLE
DB-2720 fix kazoo parsers

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
@@ -27,7 +27,7 @@
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:agent:meta}:%{NUMBER:line} \(<%{NOTSPACE:num-id}>\) %{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:agent:meta}:%{NUMBER:line} ?\(<%{NOTSPACE:num-id}>\) %{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true

--- a/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
@@ -7,7 +7,7 @@
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{WORD:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: %{WORD:level:meta}: (?:<%{WORD:agent:meta}>: %{NOTSPACE:call-id:meta}\|%{WORD:phase:meta}\||%{WORD:module:meta} \[%{NOTSPACE:code-source:meta}:%{NUMBER:line}\]:)%{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: %{WORD:level:meta}: (?:<%{WORD:agent:meta}>: %{NOTSPACE:call-id:meta}\|%{WORD:phase:meta}\||%{WORD:module:meta} \[%{NOTSPACE:code-source:meta}:%{NUMBER:line}\]:)%{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true
@@ -27,7 +27,7 @@
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{WORD:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:agent:meta}:%{NUMBER:line}\(<%{NOTSPACE:num-id}>\) %{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:agent:meta}:%{NUMBER:line} \(<%{NOTSPACE:num-id}>\) %{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true


### PR DESCRIPTION
1. modify `WORD` to `NOTSPACE` when matching `app-group` cuz `app-group` can contain `-`.
2. add an optional space in kazoo parser.

Tested locally.