### PR TITLE
DB-2842 enable close_eof for freeswitch cdr as cdr files are only updated once

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/freeswitch-nosip.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/freeswitch-nosip.yml
@@ -29,7 +29,7 @@
   fields_under_root: true
   json.keys_under_root: true
   json.add_error_key: true
-  close_inactive: 90s
+  close_eof: true
   harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true

--- a/log-collection/ansible/roles/filebeat/templates/configs/freeswitch.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/freeswitch.yml
@@ -42,7 +42,7 @@
   fields_under_root: true
   json.keys_under_root: true
   json.add_error_key: true
-  close_inactive: 90s
+  close_eof: true
   harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true

--- a/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
@@ -89,7 +89,7 @@
   fields_under_root: true
   json.keys_under_root: true
   json.add_error_key: true
-  close_inactive: 90s
+  close_eof: true
   harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true

--- a/log-collection/ansible/tests/filebeat/configs/freeswitch-nosip.yml
+++ b/log-collection/ansible/tests/filebeat/configs/freeswitch-nosip.yml
@@ -29,7 +29,7 @@
   fields_under_root: true
   json.keys_under_root: true
   json.add_error_key: true
-  close_inactive: 90s
+  close_eof: true
   harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true

--- a/log-collection/ansible/tests/filebeat/configs/freeswitch.yml
+++ b/log-collection/ansible/tests/filebeat/configs/freeswitch.yml
@@ -42,7 +42,7 @@
   fields_under_root: true
   json.keys_under_root: true
   json.add_error_key: true
-  close_inactive: 90s
+  close_eof: true
   harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true

--- a/log-collection/ansible/tests/filebeat/configs/kazoo.yml
+++ b/log-collection/ansible/tests/filebeat/configs/kazoo.yml
@@ -89,7 +89,7 @@
   fields_under_root: true
   json.keys_under_root: true
   json.add_error_key: true
-  close_inactive: 90s
+  close_eof: true
   harvester_limit: 1000
   scan_frequency: 1s
   symlinks: true


### PR DESCRIPTION
ref: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html#filebeat-input-log-close-eof