### PR TITLE
fix kazoo parsers

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
+++ b/log-collection/ansible/roles/filebeat/templates/configs/kazoo.yml
@@ -11,7 +11,7 @@
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: %{WORD:level:meta}: (?:<%{WORD:agent:meta}>: %{NOTSPACE:call-id:meta}\|%{WORD:phase:meta}\||%{WORD:module:meta} \[%{NOTSPACE:code-source:meta}:%{NUMBER:line}\]:)%{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: %{WORD:level:meta}: (?:<%{WORD:agent:meta}>: %{NOTSPACE:call-id:meta}\|%{WORD:phase:meta}\||<?%{WORD:module:meta}>? \[%{NOTSPACE:code-source:meta}:%{NUMBER:line}\]:)%{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true
@@ -35,7 +35,7 @@
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:erlang-source:meta}:%{WORD:line} ?\(<%{NOTSPACE:erlang-pid}>\) %{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:erlang-source:meta}:%{WORD:line} ?(?:\(emulator\) Error in process |)\(?<%{NOTSPACE:erlang-pid}>\)? %{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true

--- a/log-collection/ansible/tests/filebeat/configs/kazoo.yml
+++ b/log-collection/ansible/tests/filebeat/configs/kazoo.yml
@@ -6,7 +6,7 @@
     app: kamailio
     dashbase.voip.app: kamailio
     dashbase.voip.type: application_log
-    capture.src.ip: {{ kazoo_host_ip | default(hostvars[inventory_hostname]['ansible_default_ipv4']['address']) }}
+    capture.src.ip: kazoo
     capture.src.port: '0'
     _message_parser:
       type: grok
@@ -30,7 +30,7 @@
     app: kazoo
     dashbase.voip.app: kazoo
     dashbase.voip.type: application_log
-    capture.src.ip: {{ kazoo_host_ip | default(hostvars[inventory_hostname]['ansible_default_ipv4']['address']) }}
+    capture.src.ip: kazoo
     capture.src.port: '0'
     _message_parser:
       type: grok
@@ -55,7 +55,7 @@
     app: freeswitch
     dashbase.voip.app: freeswitch
     dashbase.voip.type: application_log
-    capture.src.ip: {{ kazoo_host_ip | default(hostvars[inventory_hostname]['ansible_default_ipv4']['address']) }}
+    capture.src.ip: kazoo
     capture.src.port: '11000'
     _message_parser:
       type: multi

--- a/log-collection/ansible/tests/filebeat/configs/kazoo.yml
+++ b/log-collection/ansible/tests/filebeat/configs/kazoo.yml
@@ -6,12 +6,12 @@
     app: kamailio
     dashbase.voip.app: kamailio
     dashbase.voip.type: application_log
-    capture.src.ip: kazoo
+    capture.src.ip: {{ kazoo_host_ip | default(hostvars[inventory_hostname]['ansible_default_ipv4']['address']) }}
     capture.src.port: '0'
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: %{WORD:level:meta}: (?:<%{WORD:agent:meta}>: %{NOTSPACE:call-id:meta}\|%{WORD:phase:meta}\||%{WORD:module:meta} \[%{NOTSPACE:code-source:meta}:%{NUMBER:line}\]:)%{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: %{WORD:level:meta}: (?:<%{WORD:agent:meta}>: %{NOTSPACE:call-id:meta}\|%{WORD:phase:meta}\||<?%{WORD:module:meta}>? \[%{NOTSPACE:code-source:meta}:%{NUMBER:line}\]:)%{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true
@@ -30,12 +30,12 @@
     app: kazoo
     dashbase.voip.app: kazoo
     dashbase.voip.type: application_log
-    capture.src.ip: kazoo
+    capture.src.ip: {{ kazoo_host_ip | default(hostvars[inventory_hostname]['ansible_default_ipv4']['address']) }}
     capture.src.port: '0'
     _message_parser:
       type: grok
       pattern: |-
-        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:erlang-source:meta}:%{WORD:line} ?\(<%{NOTSPACE:erlang-pid}>\) %{GREEDYDATA:message}
+        %{TIMESTAMP_ISO8601:timestamp:datetime:yyyy-MM-dd'T'HH:mm:ss.SSSSSS}%{ISO8601_TIMEZONE} %{NOTSPACE:app-group:meta} %{WORD:application:meta}\[%{NUMBER:pid}\]: \|%{NOTSPACE:call-id:meta}\|%{WORD:erlang-source:meta}:%{WORD:line} ?(?:\(emulator\) Error in process |)\(?<%{NOTSPACE:erlang-pid}>\)? %{GREEDYDATA:message}
 
   multiline.pattern: ^\d{4}-\d{2}-\d{2}
   multiline.negate: true
@@ -55,7 +55,7 @@
     app: freeswitch
     dashbase.voip.app: freeswitch
     dashbase.voip.type: application_log
-    capture.src.ip: kazoo
+    capture.src.ip: {{ kazoo_host_ip | default(hostvars[inventory_hostname]['ansible_default_ipv4']['address']) }}
     capture.src.port: '11000'
     _message_parser:
       type: multi


### PR DESCRIPTION
Example logs:
1. kazoo
    ```
    2020-09-18T09:15:40.380910+00:00 li-123 2600hz[25834]: |0000000000|Undefined:Undefined (emulator) Error in process <0.19222.28> on node ...
    ```
2. kamailio
    ```
    2020-09-18T07:16:32.275026+00:00 apps001 kamailio[27404]: ERROR: <core> [core/tcp_read.c:1505]: tcp_read_req(): ERROR: tcp_read_req: error reading - c: 0x7f2efe9c35c0 r: 0x7f2efe9c36a8 (-1)
    ```

Tested locally via dashbase-dev.

Note:
1. I found that the updated pattern for kazoo makes `(emulator) Error in process` unsearchable cuz it's not in any fields. We can discuss and make a better parser for kazoo later (merge the changes for Kamailio firstly) if it's not urgent.
2. I made the `core`(in the above error log) as `module` in the updated parser. (I'm not sure if that's correct)