### PR TITLE
[DS-674] collect all rows from the table except event_type='info'

### DIFF
--- a/log-collection/ansible/roles/logstash/tasks/main.yml
+++ b/log-collection/ansible/roles/logstash/tasks/main.yml
@@ -117,7 +117,7 @@
 
 - name: Create Netsapiens mysql_statement file
   shell: |-
-    echo "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM event_$(date +\%Y\%m\%d) WHERE event_type='responder' AND event_index > :sql_last_value">/etc/logstash/conf.d/netsapiens_mysql_statement
+    echo "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM event_$(date +\%Y\%m\%d) WHERE event_type!='info' AND event_index > :sql_last_value">/etc/logstash/conf.d/netsapiens_mysql_statement
   when: isNetsapiens.changed
 
 - name: Create Netsapiens cron job to update mysql statement based on current date
@@ -126,7 +126,7 @@
     minute: "0"
     hour: "0"
     job: |-
-      systemctl stop logstash; rm /etc/logstash/conf.d/.logstash_jdbc_last_run_netsapiens*; echo "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM event_$(date +\%Y\%m\%d) WHERE event_type='responder' AND event_index > :sql_last_value">/etc/logstash/conf.d/netsapiens_mysql_statement; systemctl start logstash
+      systemctl stop logstash; rm /etc/logstash/conf.d/.logstash_jdbc_last_run_netsapiens*; echo "SELECT event_index, hostname, event_type, orig_callid, event_text, event_ts, event_time FROM event_$(date +\%Y\%m\%d) WHERE event_type!='info' AND event_index > :sql_last_value">/etc/logstash/conf.d/netsapiens_mysql_statement; systemctl start logstash
   when: isNetsapiens.changed
 
 - name: Create Netsapiens CDR mysql_statement file


### PR DESCRIPTION
Request from Blake at Skyswitch. We used to only read events with event_type='responder' from NetSapiens database.
Blake wants to see more events since they can be useful for troubleshooting. 
This change enables to read all events from NetSapiens database EXCEPT event_type='info'. This was requested.

SELECT statement was changed from:

WHERE event_type='responder'

to:
WHERE event_type!='info'