### PR TITLE
DS-681: modified tracking column to time_release and changed sql query to acc…

### DIFF
--- a/log-collection/ansible/roles/logstash/tasks/main.yml
+++ b/log-collection/ansible/roles/logstash/tasks/main.yml
@@ -146,7 +146,7 @@
 
 - name: Create Sas CDR mysql_statement file
   shell: |-
-    echo "SELECT * FROM cdr WHERE time_start >= :sql_last_value">/etc/logstash/conf.d/sascdr_mysql_statement
+    echo "SELECT * FROM cdr WHERE time_release >= :sql_last_value AND time_release < DATE_SUB(NOW(), INTERVAL 3 second)">/etc/logstash/conf.d/sascdr_mysql_statement
   when: isSasCDR.changed
 
 - name: Create Homer mysql_statement file

--- a/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/sascdr_1.logstash.conf.j2
@@ -12,7 +12,7 @@ input {
         statement_filepath => "/etc/logstash/conf.d/sascdr_mysql_statement"
         schedule => "*/1 * * * *"
         use_column_value => true
-        tracking_column => "time_start"
+        tracking_column => "time_release"
         tracking_column_type => "timestamp"
 	}
 }


### PR DESCRIPTION
…omodate records updates
SQL query fetching sas cdr records is modified to fetch records with time_release < (NOW() - 3 second) to let calls in progress to be updated with final time_release.
We think that sas cdr records are collected before they have an update time_release and this change is addressing this.
Tested by populating 50,000 into mysql database on 54.41.161.34 AWS EC2 machine and using ansible to install logstash with sas configuration:
`ansible-playbook -i inventory deploy_logstash.yml -e "dashbase_url=https://table-logs.dashcomm-demo.dashbase.io:443 configs=sascdr_1" --connection local`