### PR TITLE
Nscdr missing fix

### DIFF
--- a/log-collection/ansible/roles/logstash/tasks/main.yml
+++ b/log-collection/ansible/roles/logstash/tasks/main.yml
@@ -131,7 +131,7 @@
 
 - name: Create Netsapiens CDR mysql_statement file
   shell: |-
-    echo "SELECT * FROM $(date +\%Y\%m)_r WHERE time_start >= :sql_last_value">/etc/logstash/conf.d/nscdr_mysql_statement
+    echo "SELECT * FROM $(date +\%Y\%m)_r WHERE time_release >= :sql_last_value AND time_release < DATE_SUB(NOW(), INTERVAL 3 second)">/etc/logstash/conf.d/nscdr_mysql_statement
   when: isNetsapiensCDR.changed
 
 - name: Create Netsapiens CDR cron job to update mysql statement based on current date

--- a/log-collection/ansible/roles/logstash/templates/configs/nscdr_1.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/nscdr_1.logstash.conf.j2
@@ -13,7 +13,7 @@ input {
                 statement_filepath => "/etc/logstash/conf.d/nscdr_mysql_statement"
                 schedule => "*/1 * * * *"
                 use_column_value => true
-                tracking_column => "time_start"
+                tracking_column => "time_release"
 	}
 }
 

--- a/log-collection/ansible/roles/logstash/templates/configs/nscdr_2.logstash.conf.j2
+++ b/log-collection/ansible/roles/logstash/templates/configs/nscdr_2.logstash.conf.j2
@@ -13,7 +13,7 @@ input {
                 statement_filepath => "/etc/logstash/conf.d/nscdr_mysql_statement"
                 schedule => "*/1 * * * *"
                 use_column_value => true
-                tracking_column => "time_start"
+                tracking_column => "time_release"
 	}
 }
 


### PR DESCRIPTION
- modified SQL query that fetches NSCDRs to use `time_release` - 3seconds to insure records are already updated when they are fetched
- modified nscdr configuration to use `time_release` as a tracking column