### PR TITLE
DB-3400 add usename passwod to filebeaat elasticsearch output

### DIFF
--- a/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
+++ b/log-collection/ansible/roles/filebeat/templates/filebeat.yml.j2
@@ -64,6 +64,8 @@ output.elasticsearch:
   hosts: "{{ dashbase_url }}"
   index: "{{ table }}"
   ssl.verification_mode: none
+  username: "{{ username }}" 
+  password: "{{ password }}"
 
 #================================ Logging =====================================
 


### PR DESCRIPTION
ticket:
https://dashbase.atlassian.net/browse/DB-3400

This PR kicks off this work. Added templating for where to specify the username/password pair. But has not implemented how to pass that in when running the playbook.