### PR TITLE
DB-3483 Add support for table token during installation

### DIFF
--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -836,7 +836,7 @@ download_dashbase() {
 create_internal_token() {
   # create 32 bits internal token
   kubectl exec -it admindash-0 -n dashbase -- bash -c "cat /dev/urandom | tr -dc 'a-z-0-9' | fold -w 32 | head -n 1 > /data/TOKEN-STRING"
-  TOKEN=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "cat -v /data/TOKEN-STRING | sed -e 's/\^M//' ")
+  TOKEN=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "cat -v /data/TOKEN-STRING | tr -d '\n'")
   log_info "created internal token is $TOKEN"
 
   # update dashbase-values.yaml file

--- a/dashbase-installer.sh
+++ b/dashbase-installer.sh
@@ -836,7 +836,7 @@ download_dashbase() {
 create_internal_token() {
   # create 32 bits internal token
   kubectl exec -it admindash-0 -n dashbase -- bash -c "cat /dev/urandom | tr -dc 'a-z-0-9' | fold -w 32 | head -n 1 > /data/TOKEN-STRING"
-  TOKEN=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "cat /data/TOKEN-STRING")
+  TOKEN=$(kubectl exec -it admindash-0 -n dashbase -- bash -c "cat -v /data/TOKEN-STRING | sed -e 's/\^M//' ")
   log_info "created internal token is $TOKEN"
 
   # update dashbase-values.yaml file
@@ -984,6 +984,7 @@ update_dashbase_valuefile() {
     kubectl exec -it admindash-0 -n dashbase -- bash -c "cd /data ; /data/configure_presto.sh"
   fi
 
+
   # update prometheus image version
   if [[ "$VERSION" == *"nightly"* ]]; then
     log_info "dashbase nightly version is used, update prometheus image to use nightly version"
@@ -1000,14 +1001,14 @@ update_dashbase_valuefile() {
     echo "username: \"$USERNAME\"" > dashbase-license.txt
     echo "license: \"$LICENSE\"" >> dashbase-license.txt
     kubectl cp dashbase-license.txt dashbase/admindash-0:/data/
-    kubectl exec -it admindash-0 -n dashbase -- bash -c "cat /data/dashbase-license.txt >> /data/dashbase-values.yaml"
+    kubectl exec -it admindash-0 -n dashbase -- bash -c "cat -v /data/dashbase-license.txt | sed -e 's/\^M//' >> /data/dashbase-values.yaml"
     kubectl exec -it admindash-0 -n dashbase -- bash -c "rm -rf dash-lapp-1.0.0-rc9.jar"
   else
     log_info "update default dashbase-values.yaml file with entered license information"
     echo "username: \"$USERNAME\"" > dashbase-license.txt
     echo "license: \"$LICENSE\"" >> dashbase-license.txt
     kubectl cp dashbase-license.txt dashbase/admindash-0:/data/
-    kubectl exec -it admindash-0 -n dashbase -- bash -c "cat /data/dashbase-license.txt >> /data/dashbase-values.yaml"
+    kubectl exec -it admindash-0 -n dashbase -- bash -c "cat -v /data/dashbase-license.txt | sed -e 's/\^M//' >> /data/dashbase-values.yaml"
   fi
 
 }

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-prod.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-prod.yaml
@@ -45,6 +45,7 @@ default:
       RETENTION_SIZE_GB: "1250"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2-prod.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2-prod.yaml
@@ -48,6 +48,7 @@ default:
       RETENTION_SIZE_GB: "1250"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values-v2.yaml
@@ -45,6 +45,7 @@ default:
       RETENTION_SIZE_GB: "1250"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/largesetup/dashbase-values.yaml
@@ -42,6 +42,7 @@ default:
       RETENTION_SIZE_GB: "1250"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values-v2.yaml
@@ -28,6 +28,7 @@ default:
       RETENTION_SIZE_GB: "8"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/localsetup/dashbase-values.yaml
@@ -25,6 +25,7 @@ default:
       RETENTION_SIZE_GB: "8"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "1"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 
 presto:

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values-v2.yaml
@@ -37,6 +37,7 @@ default:
       RETENTION_SIZE_GB: "850"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/smallsetup/dashbase-values.yaml
@@ -35,6 +35,7 @@ default:
       RETENTION_SIZE_GB: "850"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values-v2.yaml
@@ -36,6 +36,7 @@ default:
       RETENTION_SIZE_GB: "850"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "2"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 presto:
   enabled: false

--- a/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values.yaml
+++ b/deployment-tools/dashbase-admin/dashbase_setup_tarball/tinysetup/dashbase-values.yaml
@@ -33,6 +33,7 @@ default:
       RETENTION_SIZE_GB: "850"
       READER_CACHE_MEM_PERCENT: "60"
       NUM_INDEXING_THREADS: "1"
+      INTERNAL_TOKEN: "TOKENSTRING"
 
 ingress:
   enabled: true


### PR DESCRIPTION
Background.
Based on ticket https://dashbase.atlassian.net/browse/DB-3432 ; V1 table endpoints can be secured with dashbase `auth` and `INTERNAL_TOKEN`

Changes in this PR.
1. When `--basic_auth` flag is used in Install script, `INTERNAL_TOKEN` string will automatically appended in dashbase-values.yaml file under the  default v1 table env variables;   when `--basic_auth` flag is used .
2. Remove presto TLS cert creation when presto is not enabled
3. Remove LF (line feed) `^M`  trailing at the license string and TOKEN string, that is because `cat` command automatically have  line feed inserted.

Tested the default install with following command
```
./dashbase-installer.sh --platform=aws --ingress \
                                       --v1 \
                                       --subdomain=raydash1218c.dashbase.io \
                                       --basic_auth --version=2.5.5 \
                                       --cluster_type=large \
                                       --callflow_cdr --callflow_sip
```
output of dashbase install script run is attached
[dashbase_install_output_12182020c.txt](https://github.com/dashbase/dashbase-installation/files/5718752/dashbase_install_output_12182020c.txt)


And the `INTERNAL_TOKEN` variable is inserted into the v1 table default env variable section in the dashbase-values.yaml file. (see below)

```
  table:
    priorityClassName: dashbase-high-priority
    storage:
      class: "dashbase-data"
      size: "1500Gi"

    containerConfig:
      resources:
        requests:
          cpu: 3.5
          memory: 26G
        limits:
          cpu: 3.5
          memory: 26G
    environment:
      JAVA_OPTS: "-Xmx20g -Xms20g"
      IGNORE_PARSE_FAILURE: true
      BLOOM_FILTER_SIZE: "400"
      MAX_BUFFER_DELAY_IN_SEC: "1000"
      RETENTION_NUM_DAYS: "7"
      RETENTION_SIZE_GB: "1250"
      READER_CACHE_MEM_PERCENT: "60"
      NUM_INDEXING_THREADS: "2"
      INTERNAL_TOKEN: "8n4mj7pqhe84ldqvkbwrge0rp6ej12s4"
```

Tested the changes and result is positive.  trailing `^M` issue on `License`  and `TOKEN` string is resolved.

Limitation:  `INTERNAL_TOKEN` is created when `--basic_auth` flag is being used in the dashbase install script. Because you can run dashbase without auth setup. In other words, we recommend to use `--basic_auth` flag  for initial production or poc setup. And dashbase basic auth can be manually reconfigured for Okta or Google auth after initial setup.




